### PR TITLE
ci(release): port PR-based release flow from skill-llm-wiki

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,13 @@
 name: Release
 
+# Opens a release PR that bumps package.json (and package-lock.json
+# if present) to the next semver. The PR goes through the standard
+# branch-protection gates (Copilot review, code scanning, CODEOWNERS
+# approval, thread resolution) exactly like any other change — the
+# bot does not push directly to main. Once the PR merges, a separate
+# `tag-on-main.yml` workflow creates the matching `v<version>` tag,
+# which in turn fires `publish.yml`.
+
 on:
   workflow_dispatch:
     inputs:
@@ -14,31 +22,119 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
+
+# Serialize release dispatches so two operators can't race on the
+# same `release/v<version>` branch. A queued run picks up after
+# the earlier one finishes.
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  release:
-    name: Bump version & tag
+  open-release-pr:
+    name: Open release PR
     runs-on: ubuntu-latest
 
     steps:
+      - name: Refuse dispatch from non-main refs
+        # `workflow_dispatch` can be fired from the UI against any
+        # ref. We want the run to show as FAILED with a clear
+        # error when an operator accidentally picks a feature
+        # branch, not skipped/green the way a job-level `if` would
+        # render. Releases always cut from main.
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Release workflow must be dispatched from main; got ${{ github.ref }}."
+          echo "::error::Switch the branch selector in the Actions UI to \`main\` and retry."
+          exit 1
+
       - uses: actions/checkout@v4
         with:
+          # Defensive double-belt: even if the dispatch came from
+          # a non-main ref and the early step above is somehow
+          # bypassed, explicitly check out main so the bump commit
+          # is always parented to it.
+          ref: main
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
 
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version
+      - name: Bump version on a release branch
+        id: bump
         run: |
-          npm version ${{ inputs.bump }} --no-git-tag-version
-          VERSION=$(node -p "require('./package.json').version")
-          git add package.json package-lock.json
-          git commit -m "release: v${VERSION}"
-          git tag "v${VERSION}"
-          git push origin main --tags
+          # Read current to detect no-op bumps (shouldn't happen with
+          # npm version <bump>, but bail loudly if it does).
+          BEFORE=$(node -p "require('./package.json').version")
+          # --ignore-scripts: npm version runs preversion/version/
+          # postversion lifecycle scripts by default. None are defined
+          # today, but a future addition (or a transitive one via a
+          # config change) would silently run in CI with write access
+          # to the repo. Keep the bump bounded to version files only.
+          npm version ${{ inputs.bump }} --no-git-tag-version --ignore-scripts
+          AFTER=$(node -p "require('./package.json').version")
+          if [ "$BEFORE" = "$AFTER" ]; then
+            echo "::error::npm version produced no change ($BEFORE == $AFTER)"
+            exit 1
+          fi
+
+          BRANCH="release/v${AFTER}"
+          echo "version=${AFTER}" >> "$GITHUB_OUTPUT"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+          # Use -B so a stale branch from a prior failed attempt is
+          # reset in place rather than making us error out.
+          git checkout -B "${BRANCH}"
+          git add package.json
+          if [ -f package-lock.json ]; then
+            git add package-lock.json
+          fi
+          git commit -m "release: v${AFTER}"
+
+          # Push safely whether or not the branch pre-exists on the
+          # remote. actions/checkout does NOT seed remote-tracking
+          # refs for arbitrary release branches, so bare
+          # `--force-with-lease` has no base and can degrade to
+          # unsafe behaviour. We fetch the remote branch first (if
+          # it exists) and then force-with-lease using the EXPLICIT
+          # ref:sha form so the lease is actually enforced against
+          # a known SHA. If the branch doesn't exist on the remote
+          # yet, a plain push is sufficient and safe.
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+            REMOTE_SHA=$(git rev-parse "refs/remotes/origin/${BRANCH}")
+            git push --force-with-lease="refs/heads/${BRANCH}:${REMOTE_SHA}" origin "${BRANCH}"
+          else
+            git push origin "${BRANCH}"
+          fi
+
+      - name: Open or update the release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          BRANCH="${{ steps.bump.outputs.branch }}"
+          BODY="Automated release PR created by \`release.yml\`. Bumps package.json (and package-lock.json, if present) to \`v${VERSION}\`.
+
+          Once this PR merges to main, \`tag-on-main.yml\` creates the matching \`v${VERSION}\` tag, which triggers \`publish.yml\` to publish the package to npm.
+
+          Review the diff for any surprises (package-lock.json regeneration drift, etc.) before approving."
+
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "release: v${VERSION}" --body "$BODY"
+            echo "Updated existing release PR for $BRANCH"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "release: v${VERSION}" \
+              --body "$BODY"
+          fi

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -1,0 +1,186 @@
+name: Tag release on main
+
+# Fires on every push to main. Decides whether this push IS a
+# release (package.json version changed relative to the previous
+# main SHA) and, if so, creates the matching `v<version>` tag.
+# Non-release commits are a fast no-op.
+#
+# The paired `release.yml` workflow opens a bump PR; merging that
+# PR triggers this workflow, which then creates the tag, which
+# then triggers `publish.yml` (push: tags: ["v*"]).
+#
+# Why the version-change gate: without it, any non-release commit
+# landing on main after a release would see the existing
+# `v<current-version>` tag at a different commit than HEAD and
+# (correctly, in isolation) flag it as the orphan-tag failure
+# mode. But after a normal release, the tag SHOULD keep pointing
+# at the release commit while main moves forward — that's the
+# canonical state, not an error. We only treat "tag exists
+# elsewhere" as an error when THIS push was itself a release
+# (i.e. the version number just changed).
+#
+# Tag push is NOT blocked by the branch ruleset: rules target
+# refs/heads/main only; refs/tags/* is a separate namespace. The
+# default GITHUB_TOKEN is sufficient; no bypass actor needed.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+# Serialize pushes to main so two concurrent release merges can't
+# both observe the tag as absent and then race on `git push`.
+# cancel-in-progress:false because every run MUST complete:
+# cancelling a run would skip tagging a legitimate release commit.
+concurrency:
+  group: tag-on-main
+  cancel-in-progress: false
+
+jobs:
+  maybe-tag:
+    name: Tag current main if package.json version is new
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          # Match the caching used by ci.yml / publish.yml so
+          # cold-start time on every push to main is consistent
+          # across workflows.
+          cache: npm
+
+      - name: Detect whether this push changed the package version
+        id: version
+        env:
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          TAG="v${CURRENT_VERSION}"
+          echo "version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+          # `github.event.before` is 40 zeros on the very first push
+          # to a new branch (or for unusual event shapes). In those
+          # cases we can't compute a diff; be conservative and treat
+          # the push as a release attempt so the tag gets created.
+          ZERO_SHA="0000000000000000000000000000000000000000"
+          if [ -z "$GITHUB_EVENT_BEFORE" ] || [ "$GITHUB_EVENT_BEFORE" = "$ZERO_SHA" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "No previous SHA on this push; treating as release by default."
+            exit 0
+          fi
+
+          # Compare the version at this push's starting SHA to HEAD.
+          # If git can't read package.json at the before-SHA (file
+          # introduced in this push, tree rewritten, etc.), we treat
+          # the absence as a version change — the conservative
+          # direction that produces a tag rather than silently
+          # skipping. `|| true` keeps the pipeline's exit status 0
+          # under bash -eo pipefail so the step continues.
+          PREV_JSON=$(git show "${GITHUB_EVENT_BEFORE}:package.json" 2>/dev/null || true)
+          if [ -z "$PREV_JSON" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Previous package.json not readable at ${GITHUB_EVENT_BEFORE}; treating as change."
+            exit 0
+          fi
+          PREV_VERSION=$(printf '%s' "$PREV_JSON" | node -e "
+            let buf = ''
+            process.stdin.on('data', c => buf += c)
+            process.stdin.on('end', () => {
+              try { process.stdout.write(JSON.parse(buf).version || '') }
+              catch { process.stdout.write('') }
+            })
+          ")
+          if [ -z "$PREV_VERSION" ] || [ "$PREV_VERSION" != "$CURRENT_VERSION" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version changed: ${PREV_VERSION:-<unknown>} -> ${CURRENT_VERSION}; this is a release commit."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged at ${CURRENT_VERSION}; non-release commit, no-op."
+          fi
+
+      - name: Check whether the tag already exists on the remote
+        id: check
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          HEAD_SHA=$(git rev-parse HEAD)
+
+          # `git ls-remote --tags` distinguishes tag shapes:
+          #   - annotated tag: two lines — tag OBJECT sha
+          #     (refs/tags/<tag>) and dereferenced commit sha
+          #     (refs/tags/<tag>^{})
+          #   - lightweight tag: one line — commit sha under
+          #     refs/tags/<tag>
+          # Filtering on the exact refname (refs/tags/<tag>)
+          # suppresses the ^{} line, so we MUST ask for both
+          # refspecs explicitly. Otherwise the comparison below
+          # would pick the tag-object sha on annotated tags and
+          # always fail the legitimate-rerun equality check.
+          REMOTE_OUT=$(git ls-remote --tags origin \
+            "refs/tags/${TAG}" \
+            "refs/tags/${TAG}^{}" \
+            2>/dev/null || true)
+          if [ -z "$REMOTE_OUT" ]; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Prefer the dereferenced sha (commit) when the remote
+          # returns both. Fall back to the single-line form for
+          # lightweight tags.
+          REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '/\^\{\}$/ {print $1}')
+          if [ -z "$REMOTE_SHA" ]; then
+            REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '{print $1; exit}')
+          fi
+
+          if [ "$REMOTE_SHA" = "$HEAD_SHA" ]; then
+            # Tag already points at the commit we'd tag anyway —
+            # a legitimate rerun on the same main commit. No-op.
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} already points at HEAD ($HEAD_SHA); nothing to do."
+          else
+            # This push changed the version AND a tag for the new
+            # version already exists at a different commit. Classic
+            # orphan-tag failure mode: publish.yml would not fire
+            # for the current release, and the tag would stay
+            # pointed at a stale commit. Fail loudly.
+            echo "::error::Tag ${TAG} exists on the remote but points at ${REMOTE_SHA}, not the current main HEAD ${HEAD_SHA}."
+            echo "::error::This is the orphan-tag failure mode. Delete the stale tag and re-run:"
+            echo "::error::  git push origin --delete ${TAG}"
+            exit 1
+          fi
+
+      - name: Create and push the tag
+        if: steps.version.outputs.changed == 'true' && steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          TAG="${{ steps.version.outputs.tag }}"
+          git tag -a "${TAG}" -m "release ${TAG}"
+
+          # Tolerate "already exists" as success. The concurrency
+          # group above serialises runs on main, but a belt-and-
+          # suspenders guard closes the residual race where a user
+          # (or another workflow) created the same tag between our
+          # ls-remote check above and this push. We only swallow the
+          # specific "already exists" failure; any other push error
+          # still surfaces.
+          set +e
+          PUSH_OUT=$(git push origin "refs/tags/${TAG}" 2>&1)
+          PUSH_STATUS=$?
+          set -e
+          echo "$PUSH_OUT"
+          if [ $PUSH_STATUS -eq 0 ]; then
+            echo "Created and pushed tag ${TAG}"
+          elif echo "$PUSH_OUT" | grep -q "already exists"; then
+            echo "Tag ${TAG} was created concurrently; treating as success."
+          else
+            exit $PUSH_STATUS
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,9 +74,12 @@ overlays/
 
 ## Releasing
 
-Releases are automated via GitHub Actions:
+Releases are PR-gated; the bot does not push to `main` directly. One dispatch + one PR merge ships the package.
 
-1. Go to Actions → Release workflow → Run workflow
-2. Choose version bump: patch / minor / major
-3. The workflow bumps `package.json`, commits, tags, and pushes
-4. The tag triggers the Publish workflow which publishes to npm
+1. Actions → Release → Run workflow. Branch selector: `main` (any other ref is rejected). Version bump: `patch` / `minor` / `major`.
+2. The workflow bumps `package.json` on a `release/v<version>` branch and opens a release PR.
+3. Review + merge the PR.
+4. `tag-on-main.yml` detects the version change on the merge commit, creates the annotated `v<version>` tag, and pushes it.
+5. The tag push triggers `publish.yml`, which runs `index:build + validate + lint + test`, verifies tag/version agreement, and runs `npm publish --access public --provenance`.
+
+Full operator walkthrough (including troubleshooting for stale/orphan tags, non-main dispatches, and the "Allow GitHub Actions to create and approve pull requests" org-level policy) lives in the [Releasing section of the README](README.md#releasing).

--- a/README.md
+++ b/README.md
@@ -132,11 +132,49 @@ skill-code-review/
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, conventions, and release process.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and conventions.
 
-## Releases
+## Releasing
 
-See [GitHub Releases](https://github.com/ctxr-dev/skill-code-review/releases) for changelog.
+Releases are PR-gated. Version bumps land on `main` through a review gate like any other change; only the tag push is automated.
+
+### One-time setup
+
+Enable these on the repo before your first release:
+
+- Repository secret `NPM_TOKEN` set to an npm access token with publish rights on the `@ctxr` scope (`npm token create`).
+- (Optional, recommended) GitHub-managed CodeQL default setup: Security → Code security → enable default setup for `javascript-typescript` and `actions`.
+- (Optional) A branch ruleset on `main` requiring PR review + code scanning. The release flow works without it; gates are strictly stricter when enabled.
+
+### Cutting a release
+
+1. **Actions → Release → Run workflow**.
+   - Branch selector: `main` (the workflow refuses any other ref).
+   - Version bump: `patch` / `minor` / `major`.
+   - Click **Run workflow**.
+2. The workflow bumps `package.json` on a fresh `release/v<version>` branch and opens a PR to `main` titled `release: v<version>`.
+3. Review the PR (diff is just version fields). Approve + merge.
+4. On merge, `tag-on-main.yml` fires automatically:
+   - Detects the version change.
+   - Creates and pushes the annotated `v<version>` tag.
+5. The tag push fires `publish.yml`, which runs `index:build + validate + lint + test`, verifies the tag matches `package.json`, and publishes the package to npm.
+
+From **Run workflow** to **published on npm** is one dispatch + one PR merge.
+
+See [GitHub Releases](https://github.com/ctxr-dev/skill-code-review/releases) for the changelog.
+
+### Troubleshooting
+
+- **Release workflow fails with "dispatched from non-main ref"** — you selected a feature branch in the Actions UI. Re-dispatch with `main`.
+- **`tag-on-main` fails with "Tag vX.Y.Z exists but points at …"** — a stale/orphan tag from a prior failed release. Delete and re-run:
+
+  ```bash
+  git push origin --delete vX.Y.Z
+  ```
+
+  Then push an empty commit to `main` (or re-merge anything) to retrigger `tag-on-main`.
+- **`publish.yml` fails on "Verify tag matches package.json"** — tag and `package.json` disagree. Investigate the merge commit; this should not happen under the PR-based flow.
+- **GitHub Actions is not permitted to create pull requests** — org or enterprise policy blocks the `GITHUB_TOKEN` from opening PRs. Enable **Allow GitHub Actions to create and approve pull requests** at the org level (Settings → Actions → General → Workflow permissions), or ask the enterprise admin to unlock the setting.
 
 ## License
 


### PR DESCRIPTION
## Summary

Ports the PR-based release flow finalized in [skill-llm-wiki PR #2](https://github.com/ctxr-dev/skill-llm-wiki/pull/2) (commit \`cfb0705\`). Preempts the \"tag already exists\" orphan-tag failure that would hit this repo the moment a ruleset is applied to \`main\`.

### What changes

- **release.yml** rewritten: dispatch → bump on \`release/v<version>\` branch → open PR via \`gh pr create\`. No more direct push to main.
- **tag-on-main.yml** new: runs on push to main, detects version change, creates annotated tag \`v<version>\`.
- **publish.yml / ci.yml** untouched (publish.yml already fires on tag push).
- **README.md** gains a \`## Releasing\` section; **CONTRIBUTING.md** rewritten to match.
- **Out-of-band**: enabled GitHub-managed CodeQL default setup via \`gh api\` (javascript-typescript + actions).

### Guards ported (all non-negotiable, each surfaced by a Copilot review round on PR #2)

1. Explicit failing step on non-main dispatch (not a job-level \`if\`, which renders green-skipped)
2. Defensive \`ref: main\` checkout regardless
3. \`--ignore-scripts\` on \`npm version\`
4. Lease-safe push with explicit \`--force-with-lease=ref:sha\` form
5. Annotated-tag deref via dual \`ls-remote\` refspecs
6. Pipefail safety on \`git show\` of before-commit package.json
7. Concurrency groups with \`cancel-in-progress: false\`
8. Tag/version verification before publish (already in publish.yml)
9. \"Already exists\" race tolerance on tag push
10. Version-change gate so non-release pushes skip tagging

### Test plan

- [ ] Merge this PR
- [ ] Verify \`tag-on-main.yml\` fires on merge, sees no version change, no-ops
- [ ] Dispatch \`Release\` with \`bump: patch\`
- [ ] Verify release PR is opened at \`release/v1.0.7\`
- [ ] Review + merge the release PR
- [ ] Verify \`tag-on-main.yml\` creates \`v1.0.7\` tag
- [ ] Verify \`publish.yml\` publishes \`@ctxr/skill-code-review@1.0.7\` to npm

### Non-goals

- Not changing \`ci.yml\` (independent, separate cadence).
- Not harmonising \`node-version\` across repos (skill-code-review stays on 22).
- Not introducing a PAT; relies on the org-level \"Allow GitHub Actions to create and approve pull requests\" setting that was enabled during PR #2's rollout.