### PR TITLE
ci(release): port release-hardening fixes from ctxr/kit PR #1 review loop

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,20 @@ jobs:
       id-token: write
 
     steps:
+      - name: Refuse non-tag refs
+        # `workflow_dispatch` is kept (so an operator can re-run a
+        # publish for an existing tag after a transient npm outage),
+        # but it can also be fired against a branch — in which case
+        # the tag/version check below is skipped (its `if` gates on
+        # refs/tags/v*) and `npm publish` would still run. That is
+        # an untagged-publish hole. Refuse any ref that isn't a
+        # `refs/tags/v*` tag up-front, regardless of event type.
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          echo "::error::publish.yml only runs for refs/tags/v*; got ${{ github.ref }}."
+          echo "::error::Re-dispatch against an existing v<version> tag, or push a new one via the release flow."
+          exit 1
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
@@ -42,7 +56,8 @@ jobs:
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           PKG_VERSION=$(node -p "require('./package.json').version")
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)."
+            echo "::error::Investigate the merge commit; this should not happen under the PR-based flow."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,20 @@
 name: Release
 
 # Opens a release PR that bumps package.json (and package-lock.json
-# if present) to the next semver. The PR goes through the standard
-# branch-protection gates (Copilot review, code scanning, CODEOWNERS
-# approval, thread resolution) exactly like any other change — the
-# bot does not push directly to main. Once the PR merges, a separate
-# `tag-on-main.yml` workflow creates the matching `v<version>` tag,
-# which in turn fires `publish.yml`.
+# if present) to the next semver. The PR goes through whatever
+# branch-protection rules `main` has configured (review, code
+# scanning, CODEOWNERS, thread resolution) exactly like any other
+# change — the bot does not push directly to main. Once the PR
+# merges, a separate `tag-on-main.yml` workflow creates the
+# matching `v<version>` tag.
+#
+# Publishing does NOT auto-chain: tags pushed with the default
+# `GITHUB_TOKEN` do not trigger `on: push: tags` workflows (GitHub
+# design, to prevent workflow recursion). After the tag lands,
+# dispatch `publish.yml` against the tag via Actions UI (documented
+# in README `## Releasing`). To remove that manual step, swap the
+# tag-push credential in `tag-on-main.yml` for a GitHub App token
+# or fine-grained PAT.
 
 on:
   workflow_dispatch:
@@ -61,7 +69,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
+          # No `cache: npm` here: this job only runs `npm version
+          # --no-git-tag-version --ignore-scripts`, which touches
+          # package.json/package-lock.json but never installs
+          # anything. Caching would add setup overhead with no
+          # install step to benefit from it.
 
       - name: Configure git
         run: |
@@ -122,15 +134,26 @@ jobs:
         run: |
           VERSION="${{ steps.bump.outputs.version }}"
           BRANCH="${{ steps.bump.outputs.branch }}"
-          BODY="Automated release PR created by \`release.yml\`. Bumps package.json (and package-lock.json, if present) to \`v${VERSION}\`.
+          # Assemble the PR body with printf so every paragraph sits
+          # at column 0 in the final string. A previous shape used a
+          # single "..." string split across lines, which preserved
+          # the yaml-script indentation on every continuation line
+          # and made GitHub render the PR body as a <pre> code block.
+          BODY="$(printf '%s\n\n%s\n\n%s' \
+            "Automated release PR created by \`release.yml\`. Bumps package.json (and package-lock.json, if present) to \`v${VERSION}\`." \
+            "Once this PR merges to main, \`tag-on-main.yml\` creates the matching \`v${VERSION}\` tag. After the tag lands, dispatch \`publish.yml\` against \`v${VERSION}\` via Actions to publish the package to npm (see README \`## Releasing\` for why this step is manual)." \
+            "Review the diff for any surprises (package-lock.json regeneration drift, etc.) before approving.")"
 
-          Once this PR merges to main, \`tag-on-main.yml\` creates the matching \`v${VERSION}\` tag, which triggers \`publish.yml\` to publish the package to npm.
-
-          Review the diff for any surprises (package-lock.json regeneration drift, etc.) before approving."
-
-          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
-            gh pr edit "$BRANCH" --title "release: v${VERSION}" --body "$BODY"
-            echo "Updated existing release PR for $BRANCH"
+          # `gh pr view "$BRANCH"` matches closed/merged PRs too, so
+          # a previous release attempt that left a closed PR on the
+          # same head branch would cause this step to silently edit
+          # the closed PR and never open a new one — the operator
+          # would see the workflow succeed but have no PR to merge.
+          # Filter explicitly to open PRs for this head branch.
+          OPEN_PR_NUMBER="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          if [ -n "$OPEN_PR_NUMBER" ]; then
+            gh pr edit "$OPEN_PR_NUMBER" --title "release: v${VERSION}" --body "$BODY"
+            echo "Updated existing open release PR #$OPEN_PR_NUMBER for $BRANCH"
           else
             gh pr create \
               --base main \

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -6,8 +6,13 @@ name: Tag release on main
 # Non-release commits are a fast no-op.
 #
 # The paired `release.yml` workflow opens a bump PR; merging that
-# PR triggers this workflow, which then creates the tag, which
-# then triggers `publish.yml` (push: tags: ["v*"]).
+# PR triggers this workflow, which then creates the tag. The tag
+# push does NOT auto-trigger `publish.yml`: the default
+# `GITHUB_TOKEN` cannot fire other workflows (GitHub design, to
+# prevent workflow recursion). Publishing is a separate manual
+# `workflow_dispatch` on the tag, documented in README
+# `## Releasing`. Swap this step's credential for a GitHub App
+# token or PAT to remove the manual step.
 #
 # Why the version-change gate: without it, any non-release commit
 # landing on main after a release would see the existing
@@ -51,16 +56,25 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          # Match the caching used by ci.yml / publish.yml so
-          # cold-start time on every push to main is consistent
-          # across workflows.
-          cache: npm
+          # No `cache: npm` here: this job only uses `node -p` to
+          # read package.json and `git show ... | node` to extract
+          # the previous version. It never runs npm install/ci, so
+          # caching would add setup overhead with no install step
+          # to benefit from it.
 
       - name: Detect whether this push changed the package version
         id: version
         env:
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+        # GitHub Actions runs each `run:` step under `bash -e` by
+        # default. We want `pipefail` too so `git show ... | node`
+        # below fails loudly when upstream fails (instead of silently
+        # passing empty input through). `-u` catches unset-variable
+        # typos. The `|| true` on `git show` remains the explicit
+        # opt-out for the one case where absence is intentional.
+        shell: bash
         run: |
+          set -euo pipefail
           CURRENT_VERSION=$(node -p "require('./package.json').version")
           TAG="v${CURRENT_VERSION}"
           echo "version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
@@ -180,7 +194,30 @@ jobs:
           if [ $PUSH_STATUS -eq 0 ]; then
             echo "Created and pushed tag ${TAG}"
           elif echo "$PUSH_OUT" | grep -q "already exists"; then
-            echo "Tag ${TAG} was created concurrently; treating as success."
+            # Someone (or something) created this tag between our
+            # ls-remote check above and this push. "already exists"
+            # alone is not enough to treat as success: the concurrent
+            # creator may have tagged a different commit, in which
+            # case this release is orphaned (publish.yml fires for
+            # their commit, not ours). Re-read the remote tag and
+            # compare to HEAD before declaring success.
+            HEAD_SHA=$(git rev-parse HEAD)
+            VERIFY_OUT=$(git ls-remote --tags origin \
+              "refs/tags/${TAG}" \
+              "refs/tags/${TAG}^{}" \
+              2>/dev/null || true)
+            VERIFY_SHA=$(echo "$VERIFY_OUT" | awk '/\^\{\}$/ {print $1}')
+            if [ -z "$VERIFY_SHA" ]; then
+              VERIFY_SHA=$(echo "$VERIFY_OUT" | awk '{print $1; exit}')
+            fi
+            if [ "$VERIFY_SHA" = "$HEAD_SHA" ]; then
+              echo "Tag ${TAG} was created concurrently at HEAD ($HEAD_SHA); treating as success."
+            else
+              echo "::error::Tag ${TAG} was created concurrently but points at ${VERIFY_SHA:-<unknown>}, not HEAD ${HEAD_SHA}."
+              echo "::error::Another actor tagged a different commit. This release is orphaned. Delete the stale tag and re-run:"
+              echo "::error::  git push origin --delete ${TAG}"
+              exit 1
+            fi
           else
             exit $PUSH_STATUS
           fi

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -66,12 +66,14 @@ jobs:
         id: version
         env:
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
-        # GitHub Actions runs each `run:` step under `bash -e` by
-        # default. We want `pipefail` too so `git show ... | node`
-        # below fails loudly when upstream fails (instead of silently
-        # passing empty input through). `-u` catches unset-variable
-        # typos. The `|| true` on `git show` remains the explicit
-        # opt-out for the one case where absence is intentional.
+        # Set strict shell options explicitly so this step behaves
+        # predictably across environments regardless of Actions'
+        # defaults. `pipefail` makes `git show ... | node` fail
+        # loudly when an upstream command fails (instead of silently
+        # passing empty input through), and `-u` catches
+        # unset-variable typos. The `|| true` on `git show` remains
+        # the explicit opt-out for the one case where absence is
+        # intentional.
         shell: bash
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Releases are PR-gated. Version bumps land on `main` through a review gate like a
 Enable these on the repo before your first release:
 
 - Repository secret `NPM_TOKEN` set to an npm access token with publish rights on the `@ctxr` scope (`npm token create`).
+- **Settings → Actions → General → Workflow permissions**: enable **Allow GitHub Actions to create and approve pull requests** so `release.yml` can open its version-bump PR with `GITHUB_TOKEN`. If the checkbox is greyed out, an organization-level Actions policy is restricting it; ask an org admin to unlock the setting first.
 - (Optional, recommended) GitHub-managed CodeQL default setup: Security → Code security → enable default setup for `javascript-typescript` and `actions`.
 - (Optional) A branch ruleset on `main` requiring PR review + code scanning. The release flow works without it; gates are strictly stricter when enabled.
 
@@ -156,10 +157,12 @@ Enable these on the repo before your first release:
 3. Review the PR (diff is just version fields). Approve + merge.
 4. On merge, `tag-on-main.yml` fires automatically:
    - Detects the version change.
-   - Creates and pushes the annotated `v<version>` tag.
-5. The tag push fires `publish.yml`, which runs `index:build + validate + lint + test`, verifies the tag matches `package.json`, and publishes the package to npm.
+   - Creates and pushes the annotated `v<version>` tag via `GITHUB_TOKEN`.
+5. **Actions → Publish to npm → Run workflow** on the `v<version>` tag. The workflow runs `npm ci + index:build + validate + lint + test`, verifies the tag matches `package.json`, and publishes the package to npm.
 
-From **Run workflow** to **published on npm** is one dispatch + one PR merge.
+> **Why a manual dispatch for step 5?** GitHub's built-in `GITHUB_TOKEN` cannot trigger further workflows (`on: push: tags` won't fire when a workflow pushed the tag). So the tag auto-creation stops at the tag. Publishing is one extra click. To make it fully automatic, swap the push credential in `tag-on-main.yml` for a GitHub App token or fine-grained PAT stored as a repo secret, then the `push: tags` trigger on `publish.yml` will fire and step 5 happens by itself.
+
+From **Run workflow** on Release to **published on npm** is one dispatch + one PR merge + one dispatch (or one dispatch + one PR merge, once a PAT/App-token is wired in).
 
 See [GitHub Releases](https://github.com/ctxr-dev/skill-code-review/releases) for the changelog.
 
@@ -172,8 +175,8 @@ See [GitHub Releases](https://github.com/ctxr-dev/skill-code-review/releases) fo
   git push origin --delete vX.Y.Z
   ```
 
-  Then push an empty commit to `main` (or re-merge anything) to retrigger `tag-on-main`.
-- **`publish.yml` fails on "Verify tag matches package.json"** — tag and `package.json` disagree. Investigate the merge commit; this should not happen under the PR-based flow.
+  Then merge a trivial no-op PR to `main` (or revert-and-re-merge the release PR) to retrigger `tag-on-main`. Direct pushes to `main` may be blocked by branch protection, so the PR path is the reliable retrigger.
+- **`publish.yml` fails on "Verify version matches tag"** — tag and `package.json` disagree. Investigate the merge commit; this should not happen under the PR-based flow.
 - **GitHub Actions is not permitted to create pull requests** — org or enterprise policy blocks the `GITHUB_TOKEN` from opening PRs. Enable **Allow GitHub Actions to create and approve pull requests** at the org level (Settings → Actions → General → Workflow permissions), or ask the enterprise admin to unlock the setting.
 
 ## License


### PR DESCRIPTION
## Summary

PR #1 landed the core PR-based release flow. A subsequent 6-round Copilot review loop on the parallel [ctxr/kit PR #1](https://github.com/ctxr-dev/kit/pull/1) surfaced a stack of defensive gaps that were fixed there. This PR ports the same fixes over so skill-code-review and ctxr/kit stay in lockstep.

### publish.yml
- **Refuse non-tag refs** first-step guard: closes the `workflow_dispatch`-on-a-branch untagged-publish hole. `workflow_dispatch` is retained (operators can re-run publish against an existing tag after transient npm outages) but dispatching against a branch no longer silently calls `npm publish` on an untagged build.
- `::error::` annotation on tag/version mismatch so the failure is visible in Actions UI summaries.

### release.yml
- Header comment reflects the **GITHUB_TOKEN trigger rule**: tags pushed by `GITHUB_TOKEN` do NOT trigger `on: push: tags` workflows (GitHub design, to prevent workflow recursion), so publish is a separate manual dispatch until a PAT/App-token is wired into `tag-on-main.yml`.
- Drop `cache: npm`: this job only runs `npm version --no-git-tag-version --ignore-scripts` and never installs anything.
- Rebuild PR body via `printf '%s\n\n%s\n\n%s'` so paragraphs land at column 0 in the final string. The previous quoted-multi-line shape preserved yaml-script indentation and GitHub rendered the body as a `<pre>` code block. Step-5 wording also updated to match the new manual-dispatch flow.
- Gate "edit existing PR" on an **open** PR for the head branch (`gh pr list --head --state open ...`). `gh pr view "$BRANCH"` matches closed/merged PRs too, so a previous release attempt that left a closed PR would cause subsequent dispatches to silently edit the closed PR and never open a new one.

### tag-on-main.yml
- Header comment updated to explain the GITHUB_TOKEN trigger rule + the PAT/App-token upgrade path.
- Drop `cache: npm` (same reasoning: this step only uses `node -p` + `git show | node`, no install).
- Version-detect step: explicit `set -euo pipefail` under `shell: bash`. The comment claimed `bash -eo pipefail` behaviour but Actions' default shell is `-e` only, so the `git show ... | node -e` pipeline could silently swallow upstream failures. Make the claim true.
- After swallowing an "already exists" push error, **re-verify the remote tag's dereferenced SHA matches HEAD**. A concurrent creator (another workflow, a user) could still have tagged a different commit between the `ls-remote` check and the push — the previous code false-greened that orphaned release. Now fail loudly with the orphan-tag error + delete hint.

### README.md
- One-time setup: add the **"Allow GitHub Actions to create and approve pull requests"** bullet. It was only mentioned in troubleshooting before, so first-time operators would hit the failure without warning.
- Step 5: describe the manual publish dispatch + GITHUB_TOKEN trigger rule in a block-quote note, plus the PAT/App-token upgrade path.
- Troubleshooting: align the `publish.yml` step name to the actual "Verify version matches tag" text (was "Verify tag matches package.json").
- Troubleshooting: replace "push an empty commit to main" with "merge a trivial no-op PR". Direct pushes to main are blocked by branch protection under the rulesets this flow is designed for.

## Test plan

- [ ] Merge this PR.
- [ ] Verify `tag-on-main.yml` sees no version change on the merge commit, no-ops.
- [ ] Dispatch `Release` with `bump: patch`.
- [ ] Verify `release/v<new>` branch exists and a fresh release PR is open.
- [ ] Review + merge the release PR.
- [ ] Verify `tag-on-main.yml` creates the `v<new>` tag.
- [ ] Manually dispatch `Publish to npm` against `v<new>` (until a PAT is wired in).
- [ ] Verify `@ctxr/skill-code-review@<new>` on npm.

## Related

- [ctxr/kit#1](https://github.com/ctxr-dev/kit/pull/1) — parallel port carrying the same fix set (plus templates).