### PR TITLE
docs(b6): reframe code-reviewer.md as state-action reference (#11)

### DIFF
--- a/code-reviewer.md
+++ b/code-reviewer.md
@@ -14,7 +14,7 @@ You do NOT review code yourself — you scan, route, collect, deduplicate, verif
 | Runner | [`scripts/run-review.mjs`](scripts/run-review.mjs) | Drives the FSM end-to-end via `@ctxr/fsm`'s `fsm-next` / `fsm-commit` CLIs. Dispatches inline-state handlers, pauses on workers. |
 | Inline-state handlers | [`scripts/inline-states/*.mjs`](scripts/inline-states/) | Deterministic implementations of each non-worker step. (Most are pure-in/pure-out; `write-run-directory` and `emit-stdout` intentionally perform side effects — filesystem writes and stdout/stderr — but each remains byte-deterministic given identical inputs.) |
 | Worker prompts | [`fsm/workers/*.md`](fsm/workers/) | LLM-judgement steps (project-scanner, tree-descender, trim-candidates, tool-runner, specialist-coordinator). |
-| Activation gate | [`scripts/lib/activation-gate.mjs`](scripts/lib/activation-gate.mjs) | Deterministic file_globs / keyword_matches / structural_signals / escalation_from evaluation invoked by the tree-descender worker. |
+| Activation gate | [`scripts/lib/activation-gate.mjs`](scripts/lib/activation-gate.mjs) | Deterministic file_globs / keyword_matches / structural_signals / escalation_from evaluation. **Imported and invoked from inside the tree-descender worker** (not from the runner; the runner only pauses on workers). Lifting it into the runner so the worker consumes a precomputed `activated_leaves[]` from env is tracked under the B6 reframe. |
 | Report shape | [`report-format.md`](report-format.md) | Canonical JSON / markdown report contract — what `report.json` and `report.md` look like. |
 
 **The eleven prose Steps below are not the runtime spec.** They document what each FSM state *does* in human terms. Each Step now carries a callout naming its FSM state id and the handler / worker that implements it. Read the prose to understand intent; trust the linked code for what actually executes.
@@ -196,7 +196,7 @@ A path matches "risk" if it (case-insensitive) contains any of: `auth`, `crypto`
 
 ### Short-circuit clause
 
-If `tier == trivial` AND no leaf in Step 3 produces an activation match AND no `scope-*` override is set: emit empty findings, write the manifest with `short_circuited: true`, exit with GO verdict. Silence is a valid result.
+The FSM short-circuits directly from `risk_tier_triage` to `short_circuit_exit` based on the Step 2 decision inputs alone (`tier`, `risk_signals`, `scope_overrides_present`); Step 3 does not run on this path. Concretely: `tier == trivial` AND no risk signals AND no `scope-*` override ⇒ emit empty findings, write the manifest with `short_circuited: true`, exit with GO verdict. Silence is a valid result.
 
 ### Tier-cap override
 

--- a/code-reviewer.md
+++ b/code-reviewer.md
@@ -502,11 +502,11 @@ All required fields are present even when empty (e.g. `routing.stage_b.picked: [
 
 Read `report-format.md` for the canonical report structure.
 
-1. Determine format: check the `format` argument. If `auto`: markdown when invoked by a user, JSON when dispatched as a sub-agent.
+1. Determine format: check the `format` argument. Supported values are `markdown` and `json`; `auto` resolves to markdown when stdout is a TTY (interactive user) and JSON otherwise (piped / sub-agent). `yaml` is reserved for a future PR that bundles a serializer; passing it today emits a stderr notice and falls back to markdown.
 2. If `scope-severity` is set: filter issues to only include those at or above the specified severity.
 3. If `scope-gate` is set: only include the specified gates in the release readiness section.
 4. If markdown: print `report.md` content; append a final line `Manifest: <run_dir_path>/manifest.json` so the user can drill in.
-5. If json or yaml: print `report.json` content (or YAML-dump of it).
+5. If json: print `report.json` content. The `Manifest:` pointer goes to stderr so stdout remains valid JSON for downstream parsers.
 
 **Step 11 outputs:** stdout content; exit status.
 

--- a/code-reviewer.md
+++ b/code-reviewer.md
@@ -253,7 +253,7 @@ If `scope-framework=<f1>,<f2>,...` is set: restrict the descent to leaves whose 
 
 ## Step 4: LLM Trim
 
-> **Action body for FSM state `llm_trim`.** Worker: [`fsm/workers/trim-candidates.md`](fsm/workers/trim-candidates.md) (role: `trim-candidates`). Once SC-B8 ([`#13`](https://github.com/ctxr-dev/skill-code-review/issues/13)) lands, `scripts/lib/trim-output-validator.mjs` will run after the worker output and abort the run on fabricated `picked_leaves[].id`, `coverage_rescues[].file`, etc. The runner is authoritative; this prose documents intent.
+> **Action body for FSM state `llm_trim`.** Worker: [`fsm/workers/trim-candidates.md`](fsm/workers/trim-candidates.md) (role: `trim-candidates`). Once SC-B8 ([`#13`](https://github.com/ctxr-dev/skill-code-review/issues/13)) lands, a referential-integrity validator at `scripts/lib/trim-output-validator.mjs` will run after the worker output and abort the run on fabricated `picked_leaves[].id`, `coverage_rescues[].file`, etc. (Plain text rather than a link: the file is added by #13 and is not present on this branch.) The runner is authoritative; this prose documents intent.
 
 Pick the final K = `cap` leaves from Step 3's candidates with explicit per-pick justifications. One sub-agent dispatch (or inline reasoning).
 

--- a/code-reviewer.md
+++ b/code-reviewer.md
@@ -519,7 +519,7 @@ Read `report-format.md` for the canonical report structure.
 - Run Step 1 (Deep Project Scan) before any other step.
 - Run Step 2 (Risk-Tier Triage) before any LLM call. The tier sets the specialist cap and gates the short-circuit.
 - Honour the short-circuit clause: trivial diffs with no Step 3 activation match exit with empty findings and a GO verdict.
-- Run Step 3 (Tree Descent) deterministically: walk by `focus`, evaluate `activation:`. Output a candidate set with no LLM call.
+- Run Step 3 (Tree Descent): an LLM worker walks by parent `focus` semantically, but the per-leaf `activation:` evaluation is deterministic (file-glob / structural-signal / escalation matching, not judgement). Output a candidate set carrying explicit activation-match reasons.
 - Run Step 4 (LLM Trim) on Step 3's candidates. Each pick carries a justification. Each rejection carries a reason.
 - Enforce coverage in Step 4: every file in the diff is covered by ≥ 2 picked leaves; rescue from rejected when needed.
 - Run Step 5 (Tool Discovery) on the picked leaves' `tools:` declarations.

--- a/code-reviewer.md
+++ b/code-reviewer.md
@@ -4,7 +4,22 @@ You orchestrate a team of specialised code reviewers selected from a wiki of ~47
 
 You do NOT review code yourself — you scan, route, collect, deduplicate, verify, and report.
 
-> **FSM substrate.** The eleven steps below are also defined as a finite-state machine at [`fsm/code-reviewer.fsm.yaml`](fsm/code-reviewer.fsm.yaml). The engine + CLIs live in the standalone [`@ctxr/fsm`](https://github.com/ctxr-dev/fsm) package; `.fsmrc.json` at the repo root configures `fsm_path` and `storage_root`. See [`ctxr-dev/fsm/docs/orchestration-design.md`](https://github.com/ctxr-dev/fsm/blob/main/docs/orchestration-design.md) for the design substrate. The Markdown spec below remains the human-readable source of truth for the action body of each state; the YAML is the machine-readable contract for state transitions, preconditions, outputs, and worker response schemas. Both stay in sync until the FSM package's v0.4 generator collapses the duplication.
+## Runtime contract
+
+**This document describes intent. The runtime contract is code.**
+
+| Layer | File | Role |
+|---|---|---|
+| State machine | [`fsm/code-reviewer.fsm.yaml`](fsm/code-reviewer.fsm.yaml) | Authoritative state transitions, preconditions, outputs, worker response schemas. |
+| Runner | [`scripts/run-review.mjs`](scripts/run-review.mjs) | Drives the FSM end-to-end via `@ctxr/fsm`'s `fsm-next` / `fsm-commit` CLIs. Dispatches inline-state handlers, pauses on workers. |
+| Inline-state handlers | [`scripts/inline-states/*.mjs`](scripts/inline-states/) | Pure deterministic implementations of each non-worker step. |
+| Worker prompts | [`fsm/workers/*.md`](fsm/workers/) | LLM-judgement steps (tree-descender, trim-candidates, specialist-runner, etc.). |
+| Activation gate | [`scripts/lib/activation-gate.mjs`](scripts/lib/activation-gate.mjs) | Deterministic file_globs / keyword_matches / structural_signals / escalation_from evaluation invoked by the tree-descender worker. |
+| Report shape | [`report-format.md`](report-format.md) | Canonical JSON / markdown report contract — what `report.json` and `report.md` look like. |
+
+**The eleven prose Steps below are not the runtime spec.** They document what each FSM state *does* in human terms. Each Step now carries a callout naming its FSM state id and the handler / worker that implements it. Read the prose to understand intent; trust the linked code for what actually executes.
+
+> **FSM substrate.** The engine + CLIs live in the standalone [`@ctxr/fsm`](https://github.com/ctxr-dev/fsm) package; `.fsmrc.json` at the repo root configures `fsm_path` and `storage_root`. See [`ctxr-dev/fsm/docs/orchestration-design.md`](https://github.com/ctxr-dev/fsm/blob/main/docs/orchestration-design.md) for the design substrate. The Markdown narrative below documents the action body of each state in human terms; the YAML is the machine-readable contract for state transitions, preconditions, outputs, and worker response schemas. The two stay in sync until the FSM package's v0.4 generator collapses the duplication.
 
 ## Context
 
@@ -27,6 +42,8 @@ The orchestrator runs as eleven sequential steps. Each step has defined inputs a
 ---
 
 ## Step 1: Deep Project Scan
+
+> **Action body for FSM state `scan_project`.** Worker: [`fsm/workers/scan-project.md`](fsm/workers/scan-project.md). The runner is authoritative; this prose documents intent.
 
 Build a **Project Profile** that every later step consumes. Respect `scope-*` arguments.
 
@@ -149,6 +166,8 @@ repo: <name>
 
 ## Step 2: Risk-Tier Triage
 
+> **Action body for FSM state `risk_tier_triage`.** Inline-state handler: [`scripts/inline-states/risk-tier-triage.mjs`](scripts/inline-states/risk-tier-triage.mjs). Pure-function: same `(changed_paths, diff_stats, project_profile, args) → (tier, cap, risk_signals)` for every run. The runner is authoritative; this prose documents intent.
+
 Bucket the diff into one of four tiers. The tier sets the upper bound on specialist count and gates short-circuit.
 
 ### Tier rules
@@ -189,7 +208,9 @@ Explicit `max-reviewers=N` argument overrides the tier-default cap. The orchestr
 
 ## Step 3: Tree Descent
 
-Walk the wiki tree at `reviewers.wiki/` to gather a candidate leaf set. Deterministic; no LLM call.
+> **Action body for FSM state `tree_descend`.** Worker: [`fsm/workers/tree-descender.md`](fsm/workers/tree-descender.md). The worker invokes [`scripts/lib/activation-gate.mjs`](scripts/lib/activation-gate.mjs) for the deterministic activation evaluation; only the focus-descent step is LLM judgement. The runner is authoritative; this prose documents intent.
+
+Walk the wiki tree at `reviewers.wiki/` to gather a candidate leaf set. Activation evaluation (file_globs / keyword_matches / structural_signals / escalation_from) is deterministic; only the parent-`focus` semantic descent calls the LLM.
 
 ### Routing model
 
@@ -231,6 +252,8 @@ If `scope-framework=<f1>,<f2>,...` is set: restrict the descent to leaves whose 
 ---
 
 ## Step 4: LLM Trim
+
+> **Action body for FSM state `llm_trim`.** Worker: [`fsm/workers/trim-candidates.md`](fsm/workers/trim-candidates.md). Worker output is then validated for referential integrity by [`scripts/lib/trim-output-validator.mjs`](scripts/lib/trim-output-validator.mjs) (SC-B8) — fabricated `picked_leaves[].id`, `coverage_rescues[].file`, etc. abort the run before downstream consumers see them. The runner is authoritative; this prose documents intent.
 
 Pick the final K = `cap` leaves from Step 3's candidates with explicit per-pick justifications. One sub-agent dispatch (or inline reasoning).
 
@@ -277,6 +300,8 @@ The full picked + rejected output goes into `manifest.json` under `routing.stage
 
 ## Step 5: Tool Discovery
 
+> **Action body for FSM state `tool_discovery`.** Worker: [`fsm/workers/tool-discovery.md`](fsm/workers/tool-discovery.md). The runner is authoritative; this prose documents intent.
+
 Collect external tools declared by the picked leaves. Run available tools before specialist dispatch so their output flows into specialist prompts.
 
 1. Collect all `tools:` entries from each picked leaf's frontmatter. Deduplicate by `name`.
@@ -294,6 +319,8 @@ Collect external tools declared by the picked leaves. Run available tools before
 ---
 
 ## Step 6: Dispatch Specialists
+
+> **Action body for FSM state `dispatch_specialists`.** Worker: [`fsm/workers/specialist-runner.md`](fsm/workers/specialist-runner.md) (one invocation per picked leaf, dispatched in parallel by the runner). The runner is authoritative; this prose documents intent.
 
 Run all picked leaves in parallel as Agent sub-tasks.
 
@@ -321,6 +348,8 @@ Dispatch ALL specialists in parallel: emit one message with multiple Agent tool 
 
 ## Step 7: Collect Findings
 
+> **Action body for FSM state `collect_findings`.** Inline-state handler: [`scripts/inline-states/collect-findings.mjs`](scripts/inline-states/collect-findings.mjs). Dedup keyed by `(file, line, normalised_title)`; pickWinner breaks severity ties by the persisted `__winner` / `__origin` stamp, never by the changing `flagged_by[0]`. Pure-function: byte-identical output for byte-identical input. The runner is authoritative; this prose documents intent.
+
 Wait for all specialists to complete. Then:
 
 1. Collect all findings from all specialists.
@@ -334,6 +363,8 @@ Wait for all specialists to complete. Then:
 
 ## Step 8: Verify Coverage
 
+> **Action body for FSM state `verify_coverage`.** Inline-state handler: [`scripts/inline-states/verify-coverage.mjs`](scripts/inline-states/verify-coverage.mjs). Per-leaf scope is narrowed by reading each picked leaf's `activation.file_globs[]` from its on-disk frontmatter; coverage_rule_violated is set when any changed file has < 2 reviewers after rescues. The runner is authoritative; this prose documents intent.
+
 Build a coverage matrix: for every file in the diff, list which specialists reviewed it.
 
 - Every file MUST be covered by ≥ 2 specialists.
@@ -344,6 +375,8 @@ Build a coverage matrix: for every file in the diff, list which specialists revi
 ---
 
 ## Step 9: Synthesize Release Readiness
+
+> **Action body for FSM state `synthesize_release_readiness`.** Inline-state handler: [`scripts/inline-states/synthesize-release-readiness.mjs`](scripts/inline-states/synthesize-release-readiness.mjs). The eight-gate predicate match against picked leaf dimensions, the verdict computation, and the B4 hard-coverage-rule promotion to NO-GO all live in code there — the prose below describes intent. The runner is authoritative.
 
 Apply the 8-gate release readiness framework using the deduplicated findings from Step 7. Gate-to-specialist binding is **predicate-based on each leaf's `dimensions:` and `tags:`**.
 
@@ -371,6 +404,8 @@ See `release-readiness.md` (project root) for the full audit checklist per gate.
 ---
 
 ## Step 10: Write Run Directory
+
+> **Action body for FSM state `write_run_directory`.** Inline-state handler: [`scripts/inline-states/write-run-directory.mjs`](scripts/inline-states/write-run-directory.mjs). `buildReportPayload(runId, env)` produces the canonical [`report-format.md`](report-format.md) JSON shape (verdict / summary / methodology / issues / strengths / tool_results / specialists / gates / coverage); `writeRunArtefacts` persists `report.json`, `report.md`, and updates `manifest.json`. Edge states `short_circuit_exit` and `stage_a_empty` route through this state too. The runner is authoritative; this prose documents intent.
 
 Every review writes a sharded run-keyed directory at `.skill-code-review/<shard>/<run-id>/`. The directory is the canonical output; Step 11's stdout / return value is the human-readable report plus a pointer to the directory.
 
@@ -462,6 +497,8 @@ All required fields are present even when empty (e.g. `routing.stage_b.picked: [
 ---
 
 ## Step 11: Stdout / Return Value
+
+> **Action body for FSM state `emit_stdout`.** Inline-state handler: [`scripts/inline-states/emit-stdout.mjs`](scripts/inline-states/emit-stdout.mjs). Format negotiation (`auto`/`markdown`/`json`), scope-severity / scope-gate filtering, and the canonical `Manifest: <path>` trailer all live in code there. The runner is authoritative; this prose documents intent.
 
 Read `report-format.md` for the canonical report structure.
 

--- a/code-reviewer.md
+++ b/code-reviewer.md
@@ -12,8 +12,8 @@ You do NOT review code yourself — you scan, route, collect, deduplicate, verif
 |---|---|---|
 | State machine | [`fsm/code-reviewer.fsm.yaml`](fsm/code-reviewer.fsm.yaml) | Authoritative state transitions, preconditions, outputs, worker response schemas. |
 | Runner | [`scripts/run-review.mjs`](scripts/run-review.mjs) | Drives the FSM end-to-end via `@ctxr/fsm`'s `fsm-next` / `fsm-commit` CLIs. Dispatches inline-state handlers, pauses on workers. |
-| Inline-state handlers | [`scripts/inline-states/*.mjs`](scripts/inline-states/) | Pure deterministic implementations of each non-worker step. |
-| Worker prompts | [`fsm/workers/*.md`](fsm/workers/) | LLM-judgement steps (tree-descender, trim-candidates, specialist-runner, etc.). |
+| Inline-state handlers | [`scripts/inline-states/*.mjs`](scripts/inline-states/) | Deterministic implementations of each non-worker step. (Most are pure-in/pure-out; `write-run-directory` and `emit-stdout` intentionally perform side effects — filesystem writes and stdout/stderr — but each remains byte-deterministic given identical inputs.) |
+| Worker prompts | [`fsm/workers/*.md`](fsm/workers/) | LLM-judgement steps (project-scanner, tree-descender, trim-candidates, tool-runner, specialist-coordinator). |
 | Activation gate | [`scripts/lib/activation-gate.mjs`](scripts/lib/activation-gate.mjs) | Deterministic file_globs / keyword_matches / structural_signals / escalation_from evaluation invoked by the tree-descender worker. |
 | Report shape | [`report-format.md`](report-format.md) | Canonical JSON / markdown report contract — what `report.json` and `report.md` look like. |
 
@@ -43,7 +43,7 @@ The orchestrator runs as eleven sequential steps. Each step has defined inputs a
 
 ## Step 1: Deep Project Scan
 
-> **Action body for FSM state `scan_project`.** Worker: [`fsm/workers/scan-project.md`](fsm/workers/scan-project.md). The runner is authoritative; this prose documents intent.
+> **Action body for FSM state `scan_project`.** Worker: [`fsm/workers/project-scanner.md`](fsm/workers/project-scanner.md) (role: `project-scanner`). The runner is authoritative; this prose documents intent.
 
 Build a **Project Profile** that every later step consumes. Respect `scope-*` arguments.
 
@@ -253,7 +253,7 @@ If `scope-framework=<f1>,<f2>,...` is set: restrict the descent to leaves whose 
 
 ## Step 4: LLM Trim
 
-> **Action body for FSM state `llm_trim`.** Worker: [`fsm/workers/trim-candidates.md`](fsm/workers/trim-candidates.md). Worker output is then validated for referential integrity by [`scripts/lib/trim-output-validator.mjs`](scripts/lib/trim-output-validator.mjs) (SC-B8) — fabricated `picked_leaves[].id`, `coverage_rescues[].file`, etc. abort the run before downstream consumers see them. The runner is authoritative; this prose documents intent.
+> **Action body for FSM state `llm_trim`.** Worker: [`fsm/workers/trim-candidates.md`](fsm/workers/trim-candidates.md) (role: `trim-candidates`). Once SC-B8 ([`#13`](https://github.com/ctxr-dev/skill-code-review/issues/13)) lands, `scripts/lib/trim-output-validator.mjs` will run after the worker output and abort the run on fabricated `picked_leaves[].id`, `coverage_rescues[].file`, etc. The runner is authoritative; this prose documents intent.
 
 Pick the final K = `cap` leaves from Step 3's candidates with explicit per-pick justifications. One sub-agent dispatch (or inline reasoning).
 
@@ -300,7 +300,7 @@ The full picked + rejected output goes into `manifest.json` under `routing.stage
 
 ## Step 5: Tool Discovery
 
-> **Action body for FSM state `tool_discovery`.** Worker: [`fsm/workers/tool-discovery.md`](fsm/workers/tool-discovery.md). The runner is authoritative; this prose documents intent.
+> **Action body for FSM state `tool_discovery`.** Worker: [`fsm/workers/tool-runner.md`](fsm/workers/tool-runner.md) (role: `tool-runner`). The runner is authoritative; this prose documents intent.
 
 Collect external tools declared by the picked leaves. Run available tools before specialist dispatch so their output flows into specialist prompts.
 
@@ -320,7 +320,7 @@ Collect external tools declared by the picked leaves. Run available tools before
 
 ## Step 6: Dispatch Specialists
 
-> **Action body for FSM state `dispatch_specialists`.** Worker: [`fsm/workers/specialist-runner.md`](fsm/workers/specialist-runner.md) (one invocation per picked leaf, dispatched in parallel by the runner). The runner is authoritative; this prose documents intent.
+> **Action body for FSM state `dispatch_specialists`.** Worker: [`fsm/workers/specialist-coordinator.md`](fsm/workers/specialist-coordinator.md) (role: `specialist-coordinator`) — a single coordinator worker that fans out one Agent dispatch per picked leaf and aggregates the results. The runner is authoritative; this prose documents intent.
 
 Run all picked leaves in parallel as Agent sub-tasks.
 

--- a/code-reviewer.md
+++ b/code-reviewer.md
@@ -168,7 +168,7 @@ repo: <name>
 
 > **Action body for FSM state `risk_tier_triage`.** Inline-state handler: [`scripts/inline-states/risk-tier-triage.mjs`](scripts/inline-states/risk-tier-triage.mjs). Pure-function: same `(changed_paths, diff_stats, project_profile, args) → (tier, cap, risk_signals)` for every run. The runner is authoritative; this prose documents intent.
 
-Bucket the diff into one of four tiers. The tier sets the upper bound on specialist count and gates short-circuit.
+Bucket the diff into one of four tiers. The tier sets the upper bound on specialist count and gates the short-circuit transition (the FSM moves directly from `risk_tier_triage` to `short_circuit_exit` when `tier == 'trivial'` AND `len(risk_signals) == 0` AND no scope-overrides — no Step 3 round-trip required).
 
 ### Tier rules
 
@@ -378,7 +378,7 @@ Build a coverage matrix: for every file in the diff, list which specialists revi
 
 > **Action body for FSM state `synthesize_release_readiness`.** Inline-state handler: [`scripts/inline-states/synthesize-release-readiness.mjs`](scripts/inline-states/synthesize-release-readiness.mjs). The eight-gate predicate match against picked leaf dimensions, the verdict computation, and the B4 hard-coverage-rule promotion to NO-GO all live in code there — the prose below describes intent. The runner is authoritative.
 
-Apply the 8-gate release readiness framework using the deduplicated findings from Step 7. Gate-to-specialist binding is **predicate-based on each leaf's `dimensions:` and `tags:`**.
+Apply the 8-gate release readiness framework using the deduplicated findings from Step 7. Gate-to-specialist binding is **predicate-based**, using each leaf's `dimensions:` array (passed through tree_descend's response_schema) and a tag-like signal derived from the leaf id. The runtime predicates live in `synthesize-release-readiness.mjs`'s `GATE_DEFINITIONS`. Tags are not currently in the run env (the trim worker emits dimensions but not tags); the inline-state handler approximates tags from kebab-case segments of the leaf id, plus the full id, plus 2-4 segment slides — so a leaf id like `error-handling-async` matches both single-token (`error`, `handling`, `async`) and compound (`error-handling`, `handling-async`) tags. Lifting `tags:` into the env (via the trim worker's response_schema) is tracked for a later sprint.
 
 The 7-axis dimensions taxonomy (`architecture`, `correctness`, `documentation`, `performance`, `readability`, `security`, `tests`) covers the 8 gates as follows:
 

--- a/code-reviewer.md
+++ b/code-reviewer.md
@@ -518,7 +518,7 @@ Read `report-format.md` for the canonical report structure.
 
 - Run Step 1 (Deep Project Scan) before any other step.
 - Run Step 2 (Risk-Tier Triage) before any LLM call. The tier sets the specialist cap and gates the short-circuit.
-- Honour the short-circuit clause: trivial diffs with no Step 3 activation match exit with empty findings and a GO verdict.
+- Honour the short-circuit clause: when Step 2 returns `tier == trivial` AND no risk signals AND no `scope-*` override, the FSM transitions directly from `risk_tier_triage` to `short_circuit_exit` (Step 3 does not run on this path); the run exits with empty findings and a GO verdict.
 - Run Step 3 (Tree Descent): an LLM worker walks by parent `focus` semantically, but the per-leaf `activation:` evaluation is deterministic (file-glob / structural-signal / escalation matching, not judgement). Output a candidate set carrying explicit activation-match reasons.
 - Run Step 4 (LLM Trim) on Step 3's candidates. Each pick carries a justification. Each rejection carries a reason.
 - Enforce coverage in Step 4: every file in the diff is covered by ≥ 2 picked leaves; rescue from rejected when needed.

--- a/fsm/code-reviewer.fsm.yaml
+++ b/fsm/code-reviewer.fsm.yaml
@@ -384,7 +384,7 @@ fsm:
 
     # ─── Step 11 ────────────────────────────────────────────────
     - id: emit_stdout
-      purpose: "Print the report (markdown / JSON / YAML per format arg) plus manifest pointer."
+      purpose: "Print the report (markdown or JSON per format arg) plus manifest pointer. yaml is reserved (no serializer bundled yet); requesting it falls back to markdown with a stderr notice."
       preconditions:
         - "run_dir_path exists in run state"
       # Inline state: stdout side effect; no FSM-side outputs.

--- a/report-format.md
+++ b/report-format.md
@@ -15,7 +15,7 @@ When the skill is invoked, parse arguments from the invocation context as `key=v
 | Argument | Values | Default | Description |
 |----------|--------|---------|-------------|
 | help | (flag) | — | Print this argument table and exit. No review is run. |
-| format | auto, markdown, json, yaml | auto | Output format. auto = markdown for direct user, JSON when dispatched as subagent. |
+| format | auto, markdown, json | auto | Output format. auto = markdown for direct user, JSON when dispatched as subagent. `yaml` is reserved for a future PR; passing it today emits a stderr notice and falls back to markdown. |
 | full | (flag) | — | Review entire codebase, not just git diff. Respects scope-dir. |
 | base | auto, git SHA or ref | auto | Base commit for diff. Auto: merge-base with origin/main or HEAD~1. Ignored if full. |
 | head | git SHA or ref | HEAD | Head commit for diff. |
@@ -322,6 +322,6 @@ When `format=json` or auto-detected as tool context, produce this exact structur
 - `tool_results[].specialist`: string — leaf id from `reviewers.wiki/` that declared this tool
 - All arrays may be empty but must be present (no omission)
 
-### YAML Output
+### YAML Output (reserved)
 
-When `format=yaml`, produce the same structure as JSON but in YAML syntax. Same fields, same rules.
+`format=yaml` is reserved for a future PR that bundles a YAML serializer. The current `emit-stdout.mjs` handler treats it as unimplemented: it emits a stderr notice and falls back to markdown. When the serializer lands, the output structure will be the JSON form translated into YAML syntax, with the same fields and rules.

--- a/report-format.md
+++ b/report-format.md
@@ -63,7 +63,7 @@ Tools are declared in each reviewer leaf's frontmatter (`tools:` array). The orc
 
 ### Format Auto-Detection
 
-When `format=auto` (the default), `emit-stdout.mjs` resolves the format from `process.stdout.isTTY`:
+When `format=auto` (the default), [`scripts/inline-states/emit-stdout.mjs`](scripts/inline-states/emit-stdout.mjs) resolves the format from `process.stdout.isTTY`:
 
 - TTY stdout (interactive user / slash command / chat) → **markdown**
 - Non-TTY stdout (piped consumer, sub-agent, CI) → **JSON**

--- a/report-format.md
+++ b/report-format.md
@@ -15,7 +15,7 @@ When the skill is invoked, parse arguments from the invocation context as `key=v
 | Argument | Values | Default | Description |
 |----------|--------|---------|-------------|
 | help | (flag) | — | Print this argument table and exit. No review is run. |
-| format | auto, markdown, json | auto | Output format. auto = markdown for direct user, JSON when dispatched as subagent. `yaml` is reserved for a future PR; passing it today emits a stderr notice and falls back to markdown. |
+| format | auto, markdown, json | auto | Output format. `auto` resolves via the stdout TTY heuristic in `emit-stdout.mjs`: markdown when stdout is a TTY (interactive user), JSON otherwise (piped consumer / sub-agent). `yaml` is reserved for a future PR; passing it today emits a stderr notice and falls back to markdown. |
 | full | (flag) | — | Review entire codebase, not just git diff. Respects scope-dir. |
 | base | auto, git SHA or ref | auto | Base commit for diff. Auto: merge-base with origin/main or HEAD~1. Ignored if full. |
 | head | git SHA or ref | HEAD | Head commit for diff. |
@@ -63,10 +63,12 @@ Tools are declared in each reviewer leaf's frontmatter (`tools:` array). The orc
 
 ### Format Auto-Detection
 
-When `format=auto` (the default):
+When `format=auto` (the default), `emit-stdout.mjs` resolves the format from `process.stdout.isTTY`:
 
-- If the orchestrator was dispatched as a **subagent** by another agent or tool → output **JSON**
-- If the orchestrator was invoked directly by a **user** (slash command, chat) → output **markdown**
+- TTY stdout (interactive user / slash command / chat) → **markdown**
+- Non-TTY stdout (piped consumer, sub-agent, CI) → **JSON**
+
+The TTY check approximates "user vs tool" because the runner can't introspect "subagent vs user" directly from inside the process.
 
 ---
 


### PR DESCRIPTION
## Summary

Sprint B B6 — every Step section in \`code-reviewer.md\` now carries a callout naming its FSM state id and the handler / worker that implements it, plus a new top-level **Runtime contract** section that points readers at the actual code (\`scripts/run-review.mjs\`, \`fsm/code-reviewer.fsm.yaml\`, \`report-format.md\`) as the authoritative spec. Prose stays as intent documentation; the runtime is code.

## Per-step state-action callouts

| Step | FSM state | Implementation |
|---|---|---|
| 1 | \`scan_project\` | \`fsm/workers/project-scanner.md\` |
| 2 | \`risk_tier_triage\` | \`scripts/inline-states/risk-tier-triage.mjs\` |
| 3 | \`tree_descend\` | \`fsm/workers/tree-descender.md\` + \`scripts/lib/activation-gate.mjs\` |
| 4 | \`llm_trim\` | \`fsm/workers/trim-candidates.md\` + \`scripts/lib/trim-output-validator.mjs\` (B8) |
| 5 | \`tool_discovery\` | \`fsm/workers/tool-runner.md\` |
| 6 | \`dispatch_specialists\` | \`fsm/workers/specialist-coordinator.md\` |
| 7 | \`collect_findings\` | \`scripts/inline-states/collect-findings.mjs\` |
| 8 | \`verify_coverage\` | \`scripts/inline-states/verify-coverage.mjs\` |
| 9 | \`synthesize_release_readiness\` | \`scripts/inline-states/synthesize-release-readiness.mjs\` |
| 10 | \`write_run_directory\` | \`scripts/inline-states/write-run-directory.mjs\` |
| 11 | \`emit_stdout\` | \`scripts/inline-states/emit-stdout.mjs\` |

## Test plan

- [x] \`npm run lint\` — 0 errors.
- [x] \`npm run validate:fsm\` — 14 states, 0 errors.
- [x] \`npm test\` — 127/127 pass.
- [ ] CI green.
- [ ] Reviewer 0 comments on final HEAD.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

