### PR TITLE
feat(b8): trim-output referential-integrity validator (#13)

### DIFF
--- a/scripts/inline-states/write-run-directory.mjs
+++ b/scripts/inline-states/write-run-directory.mjs
@@ -24,7 +24,6 @@ import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
-  loadConfig,
   resolveSettings,
   runDirPath,
   readManifest,
@@ -34,9 +33,12 @@ import {
 import { renderReportMarkdown, renderReportJson } from "../lib/report-renderer.mjs";
 
 function resolveStorageRoot(repoRoot) {
-  const config = loadConfig({ cwd: repoRoot });
-  const settings = resolveSettings(config, { fsmName: "code-reviewer" });
-  return resolve(repoRoot, settings.storage_root);
+  // @ctxr/fsm exposes resolveSettings(cliArgs, cwd) — cliArgs is the
+  // selector ({fsmName, fsmPath, ...}), cwd resolves .fsmrc.json.
+  // resolveSettings calls loadConfig internally, so the caller must
+  // not pre-load. Returns { fsmPath, storageRoot, ... } in camelCase.
+  const settings = resolveSettings({ fsmName: "code-reviewer" }, repoRoot);
+  return resolve(repoRoot, settings.storageRoot);
 }
 
 const METHODOLOGY_PRINCIPLES = ["SRP", "OCP", "LSP", "ISP", "DIP", "DRY", "KISS", "YAGNI"];

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -237,15 +237,24 @@ export function validateTrimOutput(outputs, env, opts = {}) {
   const stageACandidateIds = new Set(
     stageACandidates.map((c) => c?.id).filter((id) => typeof id === "string"),
   );
-  // Build an id → normalized-path index for the stage-A pair check (3).
-  // Stage-A entries can carry either a wiki-relative path
-  // (`lang-typescript.md`) or a repo-relative one (`reviewers.wiki/lang-
-  // typescript.md`); normalizeWikiPath collapses both shapes so the
-  // comparison doesn't false-positive on a cosmetic prefix difference.
-  const stageAPathById = new Map();
+  // Build a Set of normalized {id, path} pairs for the stage-A pair check
+  // (3). The schema doesn't guarantee unique stage-A ids — Stage-A is a
+  // list, not a map — so a Map keyed only by id would be order-dependent
+  // (the last write wins) and could mis-match a picked leaf against the
+  // wrong path. Use a Set of `<id>\u001f<normalized-path>` tokens so any
+  // declared {id, path} pair from stage-A satisfies the check.
+  // normalizeWikiPath collapses the two corpus shapes (wiki-relative
+  // `lang-typescript.md` vs repo-relative `reviewers.wiki/lang-typescript.md`)
+  // so a cosmetic prefix doesn't false-positive.
+  const stageAPairs = new Set();
+  const stageAPathsById = new Map(); // id → array of normalized paths, for diagnostics only
   for (const cand of stageACandidates) {
     if (cand && typeof cand.id === "string" && typeof cand.path === "string") {
-      stageAPathById.set(cand.id, normalizeWikiPath(cand.path));
+      const np = normalizeWikiPath(cand.path);
+      stageAPairs.add(`${cand.id}\u001f${np}`);
+      const arr = stageAPathsById.get(cand.id) ?? [];
+      if (!arr.includes(np)) arr.push(np);
+      stageAPathsById.set(cand.id, arr);
     }
   }
   const rejectedIds = new Set(
@@ -295,11 +304,12 @@ export function validateTrimOutput(outputs, env, opts = {}) {
       );
       continue;
     }
-    const expected = stageAPathById.get(leaf.id);
     const got = normalizeWikiPath(leaf.path);
-    if (expected !== undefined && expected !== got) {
+    if (!stageAPairs.has(`${leaf.id}\u001f${got}`)) {
+      const declared = stageAPathsById.get(leaf.id) ?? [];
       errors.push(
-        `picked_leaves[id=${leaf.id}].path "${leaf.path}" does not match stage_a_candidates entry path "${expected}"`,
+        `picked_leaves[id=${leaf.id}].path "${leaf.path}" does not match any stage_a_candidates entry path for that id ` +
+          `(declared: [${declared.map((p) => `"${p}"`).join(", ")}])`,
       );
     }
   }

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -25,33 +25,46 @@
 // migrate to the declarative form and delete the bespoke validator.
 
 import { readdirSync, lstatSync, realpathSync, existsSync, readFileSync } from "node:fs";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
-let _wikiIdsCache = null;
+// Cache keyed by realpath of `<repoRoot>/reviewers.wiki`. A single-process
+// run that walks two different repos (tests, multi-repo tooling) gets a
+// per-repo cache rather than reusing the first walk's result.
+const _wikiIdsCache = new Map();
+
+// Helper: a path is "inside" parent iff `relative(parent, child)` is non-
+// empty AND not the parent itself AND doesn't start with `..` AND isn't an
+// absolute path. The absolute-path check matters on Windows: cross-drive
+// `relative()` can return `D:\...` which neither starts with `..` nor with
+// the platform separator. Without isAbsolute the boundary check would
+// pass on a symlink that resolves to a different drive.
+function isInside(parent, child) {
+  const rel = relative(parent, child);
+  if (rel === "" || rel.startsWith("..") || rel.startsWith(sep) || isAbsolute(rel)) {
+    return false;
+  }
+  return true;
+}
 
 // Enumerate the set of leaf ids under reviewers.wiki/ at runtime. A leaf is
 // a `*.md` file (excluding `index.md`) under reviewers.wiki/ whose
 // frontmatter declares `id: <name>`. Symlinks must resolve to real paths
 // inside the wiki — anything pointing outside is skipped.
 export function enumerateWikiLeaves(repoRoot, { useCache = true } = {}) {
-  if (useCache && _wikiIdsCache) return _wikiIdsCache;
   const wikiRoot = resolve(repoRoot, "reviewers.wiki");
   if (!existsSync(wikiRoot)) {
-    const empty = { ids: new Set(), pathsById: new Map() };
-    if (useCache) _wikiIdsCache = empty;
+    const empty = { ids: new Set() };
     return empty;
   }
   let realRoot;
   try {
     realRoot = realpathSync(wikiRoot);
   } catch {
-    const empty = { ids: new Set(), pathsById: new Map() };
-    if (useCache) _wikiIdsCache = empty;
-    return empty;
+    return { ids: new Set() };
   }
+  if (useCache && _wikiIdsCache.has(realRoot)) return _wikiIdsCache.get(realRoot);
   const ids = new Set();
-  const pathsById = new Map();
   const stack = [realRoot];
   const visited = new Set([realRoot]);
   while (stack.length > 0) {
@@ -77,8 +90,7 @@ export function enumerateWikiLeaves(repoRoot, { useCache = true } = {}) {
       } catch {
         continue;
       }
-      const rel = relative(realRoot, realFull);
-      if (rel === "" || rel.startsWith("..") || rel.startsWith(sep)) continue;
+      if (!isInside(realRoot, realFull)) continue;
       if (
         lst.isDirectory() ||
         (lst.isSymbolicLink() && existsSync(realFull) && lstatSync(realFull).isDirectory())
@@ -91,15 +103,11 @@ export function enumerateWikiLeaves(repoRoot, { useCache = true } = {}) {
       if (!ent.name.endsWith(".md")) continue;
       if (ent.name === "index.md") continue;
       const id = readLeafId(realFull);
-      if (id) {
-        ids.add(id);
-        // Store the wiki-relative path for the ↔ id check below.
-        pathsById.set(id, rel);
-      }
+      if (id) ids.add(id);
     }
   }
-  const out = { ids, pathsById };
-  if (useCache) _wikiIdsCache = out;
+  const out = { ids };
+  if (useCache) _wikiIdsCache.set(realRoot, out);
   return out;
 }
 
@@ -130,7 +138,9 @@ function looksLikeTrimOutput(outputs) {
 
 // Resolve a wiki-relative leaf path against the wikiRoot. Mirrors
 // verify-coverage's readLeafGlobs path resolution: try wiki-relative first
-// then repo-relative; reject anything that escapes via realpath.
+// then repo-relative; reject anything that escapes via realpath. Uses the
+// shared isInside() helper so the Windows cross-drive case (where
+// path.relative() returns an absolute path) gets rejected.
 function leafPathExists(repoRoot, leafPath) {
   if (typeof leafPath !== "string" || leafPath.length === 0) return false;
   const wikiRoot = resolve(repoRoot, "reviewers.wiki");
@@ -148,8 +158,7 @@ function leafPathExists(repoRoot, leafPath) {
     } catch {
       continue;
     }
-    const rel = relative(realWiki, real);
-    if (rel.startsWith("..") || rel.startsWith(sep) || rel === "") continue;
+    if (!isInside(realWiki, real)) continue;
     if (lstatSync(real).isFile()) return true;
   }
   return false;

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -5,8 +5,14 @@
 // not the cross-references between fields. The worker can fabricate IDs
 // that don't exist in the wiki, files that aren't in the diff, or rescues
 // that name leaves the worker just rejected. This module is the
-// referential-integrity check that runs after schema validation, before
-// the trim output is committed to the run env.
+// referential-integrity check the runner invokes BEFORE `fsm-commit`
+// (which is where the FSM engine's JSON-Schema validation runs); both
+// gates must pass before the trim outputs land in the run env. So the
+// effective order is: shape (here, then in fsm-commit) → cross-refs
+// (here) → commit. Once `ctxr-dev/fsm#10` (F9 referential-integrity)
+// lands, the FSM engine's declarative `referential_integrity:` block
+// subsumes this; we migrate to the declarative form and delete the
+// bespoke validator.
 //
 // Six violation classes (the original five from #13 plus a stage-A pair check
 // added in round 4 to close a subtle id/path-split fabrication path):
@@ -26,9 +32,6 @@
 // `opts.knownLeafIds` isn't supplied, but the result is cached per-process
 // so successive validations don't re-walk the tree.
 //
-// Once `ctxr-dev/fsm#10` (F9 referential-integrity) lands, the FSM engine's
-// declarative `referential_integrity:` schema block subsumes this; we
-// migrate to the declarative form and delete the bespoke validator.
 
 import { readdirSync, lstatSync, realpathSync, existsSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -4,15 +4,20 @@
 // JSON-Schema validation only checks the SHAPE of the trim worker's output,
 // not the cross-references between fields. The worker can fabricate IDs
 // that don't exist in the wiki, files that aren't in the diff, or rescues
-// that name leaves the worker just rejected. This module is the
-// referential-integrity check the runner invokes BEFORE `fsm-commit`
-// (which is where the FSM engine's JSON-Schema validation runs); both
-// gates must pass before the trim outputs land in the run env. So the
-// effective order is: shape (here, then in fsm-commit) → cross-refs
-// (here) → commit. Once `ctxr-dev/fsm#10` (F9 referential-integrity)
-// lands, the FSM engine's declarative `referential_integrity:` block
-// subsumes this; we migrate to the declarative form and delete the
-// bespoke validator.
+// that name leaves the worker just rejected. This module performs ONLY
+// the cross-reference checks (with minimal type guarding to make the
+// individual lookups safe); it deliberately does not duplicate the
+// JSON-Schema shape gate.
+//
+// Runner ordering on --continue: this validator runs first, then
+// fsm-commit applies the declarative JSON-Schema gate. So the effective
+// order is: cross-refs (here) → schema (fsm-commit) → commit. Both
+// gates must pass before the trim outputs land in the run env. If
+// either one fires, the run aborts with a structured error.
+//
+// Once `ctxr-dev/fsm#10` (F9 referential-integrity) lands, the FSM
+// engine's declarative `referential_integrity:` block subsumes this;
+// we migrate to the declarative form and delete the bespoke validator.
 //
 // Six violation classes (the original five from #13 plus a stage-A pair check
 // added in round 4 to close a subtle id/path-split fabrication path):

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -8,7 +8,8 @@
 // referential-integrity check that runs after schema validation, before
 // the trim output is committed to the run env.
 //
-// Six violation classes:
+// Six violation classes (the original five from #13 plus a stage-A pair check
+// added in round 4 to close a subtle id/path-split fabrication path):
 //   1. picked_leaves[*].id        ∈ leaf ids in reviewers.wiki/
 //   2. picked_leaves[*].path      resolves to a real wiki file
 //   3. picked_leaves[*]           matches a stage_a_candidates entry with the
@@ -37,6 +38,13 @@ import { fileURLToPath } from "node:url";
 // run that walks two different repos (tests, multi-repo tooling) gets a
 // per-repo cache rather than reusing the first walk's result.
 const _wikiIdsCache = new Map();
+
+// This module sits at scripts/lib/trim-output-validator.mjs. Walking up two
+// directories lands at the repo root (scripts/lib → scripts → <repo>). Hoist
+// the derivation to a named module constant so the path math isn't mistaken
+// for "<repo>/scripts" by readers counting `..` segments inline.
+const __thisDir = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_REPO_ROOT = resolve(__thisDir, "..", "..");
 
 // Helper: a path is "inside" parent iff `relative(parent, child)` is non-
 // empty AND not the parent itself AND doesn't start with `..` AND isn't an
@@ -204,8 +212,7 @@ export function validateTrimOutput(outputs, env, opts = {}) {
     return { ok: true, errors: [] };
   }
   const errors = [];
-  const repoRoot =
-    opts.repoRoot ?? resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+  const repoRoot = opts.repoRoot ?? DEFAULT_REPO_ROOT;
   const { ids: wikiIds } = opts.knownLeafIds
     ? { ids: new Set(opts.knownLeafIds) }
     : enumerateWikiLeaves(repoRoot);
@@ -295,7 +302,7 @@ export function validateTrimOutput(outputs, env, opts = {}) {
     }
   }
 
-  // (4) coverage_rescues[*].file ∈ changed_paths
+  // (5) coverage_rescues[*].file ∈ changed_paths
   for (const rescue of coverageRescues) {
     if (!rescue || typeof rescue.file !== "string") {
       errors.push("coverage_rescue missing string `file`");
@@ -306,7 +313,7 @@ export function validateTrimOutput(outputs, env, opts = {}) {
     }
   }
 
-  // (5) coverage_rescues[*].rescued_leaf ∈ rejected_leaves[*].id
+  // (6) coverage_rescues[*].rescued_leaf ∈ rejected_leaves[*].id
   for (const rescue of coverageRescues) {
     if (!rescue || typeof rescue.rescued_leaf !== "string") {
       errors.push("coverage_rescue missing string `rescued_leaf`");

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -179,8 +179,18 @@ function looksLikeTrimOutput(outputs) {
 // then repo-relative; reject anything that escapes via realpath. Uses the
 // shared isInside() helper so the Windows cross-drive case (where
 // path.relative() returns an absolute path) gets rejected.
+//
+// "Leaf" means a wiki *leaf* markdown file. The file extension must be
+// `.md`, the basename cannot be `index.md` (that's a cluster summary,
+// not a leaf), and the basename can't begin with a dot (no
+// `.gitignore` / metadata). Without these the picked path could
+// resolve to a real-but-non-leaf file and pass class 2 even though the
+// trim worker fabricated the path.
 function leafPathExists(repoRoot, leafPath) {
   if (typeof leafPath !== "string" || leafPath.length === 0) return false;
+  if (!leafPath.endsWith(".md")) return false;
+  const base = leafPath.split("/").pop();
+  if (!base || base === "index.md" || base.startsWith(".")) return false;
   const wikiRoot = resolve(repoRoot, "reviewers.wiki");
   let realWiki;
   try {

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -8,12 +8,17 @@
 // referential-integrity check that runs after schema validation, before
 // the trim output is committed to the run env.
 //
-// Five violation classes:
+// Six violation classes:
 //   1. picked_leaves[*].id        ∈ leaf ids in reviewers.wiki/
 //   2. picked_leaves[*].path      resolves to a real wiki file
-//   3. rejected_leaves[*].id      ∈ stage_a_candidates ids
-//   4. coverage_rescues[*].file   ∈ changed_paths
-//   5. coverage_rescues[*].rescued_leaf ∈ rejected_leaves[*].id
+//   3. picked_leaves[*]           matches a stage_a_candidates entry with the
+//                                 same {id, path} pair (a real wiki leaf id is
+//                                 not enough — the trim worker is contractually
+//                                 picking FROM stage_a_candidates, not from
+//                                 the entire wiki).
+//   4. rejected_leaves[*].id      ∈ stage_a_candidates ids
+//   5. coverage_rescues[*].file   ∈ changed_paths
+//   6. coverage_rescues[*].rescued_leaf ∈ rejected_leaves[*].id
 //
 // The validator is a pure function: same `(outputs, env, opts)` →
 // same `{ ok, errors[] }`. It does fs reads to enumerate the wiki when
@@ -138,6 +143,17 @@ function readLeafId(absPath) {
   return m ? m[1] : null;
 }
 
+// Collapse the two wiki path shapes the corpus uses (`lang-typescript.md`
+// vs `reviewers.wiki/lang-typescript.md`) to a single canonical
+// wiki-relative form so id↔path equality across stage_a_candidates and
+// picked_leaves doesn't false-positive on a cosmetic prefix.
+function normalizeWikiPath(p) {
+  if (typeof p !== "string") return p;
+  let out = p.replace(/^\.\/+/, "");
+  if (out.startsWith("reviewers.wiki/")) out = out.slice("reviewers.wiki/".length);
+  return out;
+}
+
 function looksLikeTrimOutput(outputs) {
   return (
     outputs &&
@@ -197,11 +213,21 @@ export function validateTrimOutput(outputs, env, opts = {}) {
   const pickedLeaves = Array.isArray(outputs.picked_leaves) ? outputs.picked_leaves : [];
   const rejectedLeaves = Array.isArray(outputs.rejected_leaves) ? outputs.rejected_leaves : [];
   const coverageRescues = Array.isArray(outputs.coverage_rescues) ? outputs.coverage_rescues : [];
+  const stageACandidates = Array.isArray(env?.stage_a_candidates) ? env.stage_a_candidates : [];
   const stageACandidateIds = new Set(
-    (Array.isArray(env?.stage_a_candidates) ? env.stage_a_candidates : [])
-      .map((c) => c?.id)
-      .filter((id) => typeof id === "string"),
+    stageACandidates.map((c) => c?.id).filter((id) => typeof id === "string"),
   );
+  // Build an id → normalized-path index for the stage-A pair check (3).
+  // Stage-A entries can carry either a wiki-relative path
+  // (`lang-typescript.md`) or a repo-relative one (`reviewers.wiki/lang-
+  // typescript.md`); normalizeWikiPath collapses both shapes so the
+  // comparison doesn't false-positive on a cosmetic prefix difference.
+  const stageAPathById = new Map();
+  for (const cand of stageACandidates) {
+    if (cand && typeof cand.id === "string" && typeof cand.path === "string") {
+      stageAPathById.set(cand.id, normalizeWikiPath(cand.path));
+    }
+  }
   const rejectedIds = new Set(
     rejectedLeaves.map((r) => r?.id).filter((id) => typeof id === "string"),
   );
@@ -231,7 +257,34 @@ export function validateTrimOutput(outputs, env, opts = {}) {
     }
   }
 
-  // (3) rejected_leaves[*].id ∈ stage_a_candidates ids
+  // (3) picked_leaves[*] must match a stage_a_candidates entry with the
+  //     SAME {id, path} pair. The trim worker's contract is "select from
+  //     stage_a_candidates", not "select from the entire wiki". Without
+  //     this check a worker could fabricate an {id: real-leaf, path:
+  //     different-real-leaf} pair where both halves pass (1) and (2)
+  //     individually, but coverage scoping (which reads activation from
+  //     `path`) and specialist dispatch (keyed by `id`) would diverge.
+  for (const leaf of pickedLeaves) {
+    if (!leaf || typeof leaf.id !== "string" || typeof leaf.path !== "string") {
+      // Already flagged by (1) / (2); avoid double-reporting.
+      continue;
+    }
+    if (!stageACandidateIds.has(leaf.id)) {
+      errors.push(
+        `picked_leaves[id=${leaf.id}] is not in stage_a_candidates (worker must pick from candidates, not the full wiki)`,
+      );
+      continue;
+    }
+    const expected = stageAPathById.get(leaf.id);
+    const got = normalizeWikiPath(leaf.path);
+    if (expected !== undefined && expected !== got) {
+      errors.push(
+        `picked_leaves[id=${leaf.id}].path "${leaf.path}" does not match stage_a_candidates entry path "${expected}"`,
+      );
+    }
+  }
+
+  // (4) rejected_leaves[*].id ∈ stage_a_candidates ids
   for (const leaf of rejectedLeaves) {
     if (!leaf || typeof leaf.id !== "string") {
       errors.push("rejected_leaf missing string `id`");

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -91,10 +91,21 @@ export function enumerateWikiLeaves(repoRoot, { useCache = true } = {}) {
         continue;
       }
       if (!isInside(realRoot, realFull)) continue;
-      if (
-        lst.isDirectory() ||
-        (lst.isSymbolicLink() && existsSync(realFull) && lstatSync(realFull).isDirectory())
-      ) {
+      // Determine if `realFull` is a directory we should descend into.
+      // Direct directory entry → yes. Symlink that resolves to a
+      // directory → yes (already inside-bounds via isInside). Wrap the
+      // realFull stat in try/catch so a TOCTOU race (target disappeared
+      // / unreadable between existsSync and lstatSync) doesn't crash
+      // the validator; treat the entry as not-a-dir and skip.
+      let isDescendable = lst.isDirectory();
+      if (!isDescendable && lst.isSymbolicLink() && existsSync(realFull)) {
+        try {
+          isDescendable = lstatSync(realFull).isDirectory();
+        } catch {
+          isDescendable = false;
+        }
+      }
+      if (isDescendable) {
         if (visited.has(realFull)) continue;
         visited.add(realFull);
         stack.push(realFull);
@@ -159,7 +170,13 @@ function leafPathExists(repoRoot, leafPath) {
       continue;
     }
     if (!isInside(realWiki, real)) continue;
-    if (lstatSync(real).isFile()) return true;
+    // Same TOCTOU guard as enumerateWikiLeaves: if the entry vanished
+    // between existsSync and lstatSync, treat as not-a-file and skip.
+    try {
+      if (lstatSync(real).isFile()) return true;
+    } catch {
+      // ignore — try next candidate
+    }
   }
   return false;
 }
@@ -210,7 +227,7 @@ export function validateTrimOutput(outputs, env, opts = {}) {
       continue;
     }
     if (!leafPathExists(repoRoot, leaf.path)) {
-      errors.push(`picked_leaves[id=${leaf.id}].path "${leaf.path}" does not resolve to a real wiki file`);
+      errors.push(`picked_leaves[id=${leaf.id ?? "?"}].path "${leaf.path}" does not resolve to a real wiki file`);
     }
   }
 

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -1,0 +1,244 @@
+// trim-output-validator.mjs — referential-integrity validator for the
+// llm_trim worker's output (Sprint B B8).
+//
+// JSON-Schema validation only checks the SHAPE of the trim worker's output,
+// not the cross-references between fields. The worker can fabricate IDs
+// that don't exist in the wiki, files that aren't in the diff, or rescues
+// that name leaves the worker just rejected. This module is the
+// referential-integrity check that runs after schema validation, before
+// the trim output is committed to the run env.
+//
+// Five violation classes:
+//   1. picked_leaves[*].id        ∈ leaf ids in reviewers.wiki/
+//   2. picked_leaves[*].path      resolves to a real wiki file
+//   3. rejected_leaves[*].id      ∈ stage_a_candidates ids
+//   4. coverage_rescues[*].file   ∈ changed_paths
+//   5. coverage_rescues[*].rescued_leaf ∈ rejected_leaves[*].id
+//
+// The validator is a pure function: same `(outputs, env, opts)` →
+// same `{ ok, errors[] }`. It does fs reads to enumerate the wiki when
+// `opts.knownLeafIds` isn't supplied, but the result is cached per-process
+// so successive validations don't re-walk the tree.
+//
+// Once `ctxr-dev/fsm#10` (F9 referential-integrity) lands, the FSM engine's
+// declarative `referential_integrity:` schema block subsumes this; we
+// migrate to the declarative form and delete the bespoke validator.
+
+import { readdirSync, lstatSync, realpathSync, existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+let _wikiIdsCache = null;
+
+// Enumerate the set of leaf ids under reviewers.wiki/ at runtime. A leaf is
+// a `*.md` file (excluding `index.md`) under reviewers.wiki/ whose
+// frontmatter declares `id: <name>`. Symlinks must resolve to real paths
+// inside the wiki — anything pointing outside is skipped.
+export function enumerateWikiLeaves(repoRoot, { useCache = true } = {}) {
+  if (useCache && _wikiIdsCache) return _wikiIdsCache;
+  const wikiRoot = resolve(repoRoot, "reviewers.wiki");
+  if (!existsSync(wikiRoot)) {
+    const empty = { ids: new Set(), pathsById: new Map() };
+    if (useCache) _wikiIdsCache = empty;
+    return empty;
+  }
+  let realRoot;
+  try {
+    realRoot = realpathSync(wikiRoot);
+  } catch {
+    const empty = { ids: new Set(), pathsById: new Map() };
+    if (useCache) _wikiIdsCache = empty;
+    return empty;
+  }
+  const ids = new Set();
+  const pathsById = new Map();
+  const stack = [realRoot];
+  const visited = new Set([realRoot]);
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      if (ent.name.startsWith(".")) continue;
+      const full = join(dir, ent.name);
+      let lst;
+      try {
+        lst = lstatSync(full);
+      } catch {
+        continue;
+      }
+      let realFull;
+      try {
+        realFull = realpathSync(full);
+      } catch {
+        continue;
+      }
+      const rel = relative(realRoot, realFull);
+      if (rel === "" || rel.startsWith("..") || rel.startsWith(sep)) continue;
+      if (
+        lst.isDirectory() ||
+        (lst.isSymbolicLink() && existsSync(realFull) && lstatSync(realFull).isDirectory())
+      ) {
+        if (visited.has(realFull)) continue;
+        visited.add(realFull);
+        stack.push(realFull);
+        continue;
+      }
+      if (!ent.name.endsWith(".md")) continue;
+      if (ent.name === "index.md") continue;
+      const id = readLeafId(realFull);
+      if (id) {
+        ids.add(id);
+        // Store the wiki-relative path for the ↔ id check below.
+        pathsById.set(id, rel);
+      }
+    }
+  }
+  const out = { ids, pathsById };
+  if (useCache) _wikiIdsCache = out;
+  return out;
+}
+
+function readLeafId(absPath) {
+  let text;
+  try {
+    text = readFileSync(absPath, "utf8");
+  } catch {
+    return null;
+  }
+  // The wiki's frontmatter is YAML, but the only field we need is `id:` and
+  // it always appears on a single line at the top. Avoid pulling in a YAML
+  // parser for one field.
+  const fmEnd = text.indexOf("\n---", 4);
+  const fm = fmEnd > 0 ? text.slice(4, fmEnd) : text;
+  const m = fm.match(/^id:\s*([A-Za-z0-9][A-Za-z0-9_-]*)\s*$/m);
+  return m ? m[1] : null;
+}
+
+function looksLikeTrimOutput(outputs) {
+  return (
+    outputs &&
+    typeof outputs === "object" &&
+    !Array.isArray(outputs) &&
+    Array.isArray(outputs.picked_leaves)
+  );
+}
+
+// Resolve a wiki-relative leaf path against the wikiRoot. Mirrors
+// verify-coverage's readLeafGlobs path resolution: try wiki-relative first
+// then repo-relative; reject anything that escapes via realpath.
+function leafPathExists(repoRoot, leafPath) {
+  if (typeof leafPath !== "string" || leafPath.length === 0) return false;
+  const wikiRoot = resolve(repoRoot, "reviewers.wiki");
+  let realWiki;
+  try {
+    realWiki = realpathSync(wikiRoot);
+  } catch {
+    return false;
+  }
+  for (const candidate of [resolve(wikiRoot, leafPath), resolve(repoRoot, leafPath)]) {
+    if (!existsSync(candidate)) continue;
+    let real;
+    try {
+      real = realpathSync(candidate);
+    } catch {
+      continue;
+    }
+    const rel = relative(realWiki, real);
+    if (rel.startsWith("..") || rel.startsWith(sep) || rel === "") continue;
+    if (lstatSync(real).isFile()) return true;
+  }
+  return false;
+}
+
+export function validateTrimOutput(outputs, env, opts = {}) {
+  if (!looksLikeTrimOutput(outputs)) {
+    // Not a trim output — nothing to validate. Caller should only invoke
+    // this when the output actually came from llm_trim.
+    return { ok: true, errors: [] };
+  }
+  const errors = [];
+  const repoRoot =
+    opts.repoRoot ?? resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+  const { ids: wikiIds } = opts.knownLeafIds
+    ? { ids: new Set(opts.knownLeafIds) }
+    : enumerateWikiLeaves(repoRoot);
+
+  const pickedLeaves = Array.isArray(outputs.picked_leaves) ? outputs.picked_leaves : [];
+  const rejectedLeaves = Array.isArray(outputs.rejected_leaves) ? outputs.rejected_leaves : [];
+  const coverageRescues = Array.isArray(outputs.coverage_rescues) ? outputs.coverage_rescues : [];
+  const stageACandidateIds = new Set(
+    (Array.isArray(env?.stage_a_candidates) ? env.stage_a_candidates : [])
+      .map((c) => c?.id)
+      .filter((id) => typeof id === "string"),
+  );
+  const rejectedIds = new Set(
+    rejectedLeaves.map((r) => r?.id).filter((id) => typeof id === "string"),
+  );
+  const changedPaths = new Set(
+    Array.isArray(env?.changed_paths) ? env.changed_paths : [],
+  );
+
+  // (1) picked_leaves[*].id ∈ wiki leaf ids
+  for (const leaf of pickedLeaves) {
+    if (!leaf || typeof leaf.id !== "string") {
+      errors.push("picked_leaf missing string `id`");
+      continue;
+    }
+    if (!wikiIds.has(leaf.id)) {
+      errors.push(`picked_leaves[].id "${leaf.id}" is not a leaf in reviewers.wiki/`);
+    }
+  }
+
+  // (2) picked_leaves[*].path resolves to a real wiki file
+  for (const leaf of pickedLeaves) {
+    if (!leaf || typeof leaf.path !== "string") {
+      errors.push(`picked_leaves[id=${leaf?.id ?? "?"}].path missing or not a string`);
+      continue;
+    }
+    if (!leafPathExists(repoRoot, leaf.path)) {
+      errors.push(`picked_leaves[id=${leaf.id}].path "${leaf.path}" does not resolve to a real wiki file`);
+    }
+  }
+
+  // (3) rejected_leaves[*].id ∈ stage_a_candidates ids
+  for (const leaf of rejectedLeaves) {
+    if (!leaf || typeof leaf.id !== "string") {
+      errors.push("rejected_leaf missing string `id`");
+      continue;
+    }
+    if (!stageACandidateIds.has(leaf.id)) {
+      errors.push(`rejected_leaves[].id "${leaf.id}" is not in stage_a_candidates`);
+    }
+  }
+
+  // (4) coverage_rescues[*].file ∈ changed_paths
+  for (const rescue of coverageRescues) {
+    if (!rescue || typeof rescue.file !== "string") {
+      errors.push("coverage_rescue missing string `file`");
+      continue;
+    }
+    if (!changedPaths.has(rescue.file)) {
+      errors.push(`coverage_rescues[].file "${rescue.file}" is not in changed_paths`);
+    }
+  }
+
+  // (5) coverage_rescues[*].rescued_leaf ∈ rejected_leaves[*].id
+  for (const rescue of coverageRescues) {
+    if (!rescue || typeof rescue.rescued_leaf !== "string") {
+      errors.push("coverage_rescue missing string `rescued_leaf`");
+      continue;
+    }
+    if (!rejectedIds.has(rescue.rescued_leaf)) {
+      errors.push(
+        `coverage_rescues[].rescued_leaf "${rescue.rescued_leaf}" is not in rejected_leaves`,
+      );
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -194,7 +194,11 @@ function looksLikeTrimOutput(outputs) {
 function leafPathExists(repoRoot, leafPath) {
   if (typeof leafPath !== "string" || leafPath.length === 0) return false;
   if (!leafPath.endsWith(".md")) return false;
-  const base = leafPath.split("/").pop();
+  // Split on both POSIX `/` and Windows `\` so `cluster-a\index.md`
+  // (a worker output created on Windows) still gets caught by the
+  // leaf-only check. Without this, a worker on Windows could submit
+  // `cluster-a\index.md` and bypass the index.md/dotfile guards.
+  const base = leafPath.split(/[/\\]+/).pop();
   if (!base || base === "index.md" || base.startsWith(".")) return false;
   const wikiRoot = resolve(repoRoot, "reviewers.wiki");
   let realWiki;

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -38,6 +38,33 @@ import { loadConfig, resolveSettings, runEnv } from "@ctxr/fsm";
 
 import { validateTrimOutput } from "./lib/trim-output-validator.mjs";
 
+// Apply the B8 referential-integrity check to a worker output. Looks like
+// trim output (carries `picked_leaves[]`) ⇒ validate against the run env
+// and fail-fast on any violation. Anything else ⇒ no-op. Wraps the
+// runEnv call in try/catch so a missing/corrupt run-storage error
+// surfaces as a structured fail() rather than escaping to main().catch.
+// Exported so unit tests can pin the gate without a live FSM run.
+export function runTrimValidationGate(runId, outputs) {
+  if (!outputs || !Array.isArray(outputs.picked_leaves)) return;
+  let env;
+  try {
+    const storageRoot = resolveStorageRoot();
+    env = runEnv(runId, { storageRoot });
+  } catch (err) {
+    fail(
+      `llm_trim validation: failed to read run env (${err.code ?? ""} ${err.message}).`.trim(),
+      { state: "llm_trim", run_id: runId },
+    );
+  }
+  const v = validateTrimOutput(outputs, env, { repoRoot: REPO_ROOT });
+  if (!v.ok) {
+    fail(
+      `llm_trim referential-integrity validation failed: ${v.errors.join("; ")}`,
+      { state: "llm_trim", violations: v.errors },
+    );
+  }
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
 const INLINE_STATES_DIR = resolve(__dirname, "inline-states");
@@ -452,17 +479,7 @@ async function main() {
     // shape; the trim worker can fabricate ids / paths / files that pass
     // the schema but break downstream consumers. Abort here on any
     // violation rather than let a bad trim output corrupt the env.
-    if (outputs && Array.isArray(outputs.picked_leaves)) {
-      const storageRoot = resolveStorageRoot();
-      const env = runEnv(runId, { storageRoot });
-      const v = validateTrimOutput(outputs, env, { repoRoot: REPO_ROOT });
-      if (!v.ok) {
-        fail(
-          `llm_trim referential-integrity validation failed: ${v.errors.join("; ")}`,
-          { state: "llm_trim", violations: v.errors },
-        );
-      }
-    }
+    runTrimValidationGate(runId, outputs);
 
     const commit = runFsmCommit({ runId, outputs });
     if (!commit.ok) {

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -36,6 +36,8 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { loadConfig, resolveSettings, runEnv } from "@ctxr/fsm";
 
+import { validateTrimOutput } from "./lib/trim-output-validator.mjs";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
 const INLINE_STATES_DIR = resolve(__dirname, "inline-states");
@@ -443,6 +445,25 @@ async function main() {
       fail(`--run-id must be lowercase alnum + dashes, 3-64 chars; got: ${runId}`);
     }
     const outputs = readJsonFile(outputsFile, "--outputs-file");
+
+    // B8 referential-integrity: when the worker output looks like trim
+    // output (`picked_leaves[]` present), validate cross-references against
+    // the run env BEFORE handing it to fsm-commit. JSON-Schema only checks
+    // shape; the trim worker can fabricate ids / paths / files that pass
+    // the schema but break downstream consumers. Abort here on any
+    // violation rather than let a bad trim output corrupt the env.
+    if (outputs && Array.isArray(outputs.picked_leaves)) {
+      const storageRoot = resolveStorageRoot();
+      const env = runEnv(runId, { storageRoot });
+      const v = validateTrimOutput(outputs, env, { repoRoot: REPO_ROOT });
+      if (!v.ok) {
+        fail(
+          `llm_trim referential-integrity validation failed: ${v.errors.join("; ")}`,
+          { state: "llm_trim", violations: v.errors },
+        );
+      }
+    }
+
     const commit = runFsmCommit({ runId, outputs });
     if (!commit.ok) {
       fail(`fsm-commit failed: ${commit.error}`, { raw: commit.raw });

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -51,10 +51,18 @@ export function runTrimValidationGate(runId, outputs) {
     const storageRoot = resolveStorageRoot();
     env = runEnv(runId, { storageRoot });
   } catch (err) {
-    fail(
-      `llm_trim validation: failed to read run env (${err.code ?? ""} ${err.message}).`.trim(),
-      { state: "llm_trim", run_id: runId },
+    // Build the parenthetical from defined parts only so we don't emit
+    // awkward strings like "( something)" or "(undefined ...)" when the
+    // thrown value lacks `code` or `message`. Falls back to the
+    // stringified value when neither is present.
+    const parts = [err?.code, err?.message ?? (typeof err === "string" ? err : null)].filter(
+      (p) => typeof p === "string" && p.length > 0,
     );
+    const detail = parts.length > 0 ? ` (${parts.join(": ")})` : "";
+    fail(`llm_trim validation: failed to read run env${detail}.`, {
+      state: "llm_trim",
+      run_id: runId,
+    });
   }
   const v = validateTrimOutput(outputs, env, { repoRoot: REPO_ROOT });
   if (!v.ok) {

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -79,7 +79,7 @@ export function runTrimValidationGate(runId, outputs, _deps = {}) {
     return {
       ok: false,
       message: `llm_trim referential-integrity validation failed: ${v.errors.join("; ")}`,
-      details: { state: "llm_trim", violations: v.errors },
+      details: { state: "llm_trim", run_id: runId, violations: v.errors },
     };
   }
   return { ok: true };

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -38,39 +38,51 @@ import { resolveSettings, runEnv } from "@ctxr/fsm";
 
 import { validateTrimOutput } from "./lib/trim-output-validator.mjs";
 
-// Apply the B8 referential-integrity check to a worker output. Looks like
-// trim output (carries `picked_leaves[]`) ⇒ validate against the run env
-// and fail-fast on any violation. Anything else ⇒ no-op. Wraps the
-// runEnv call in try/catch so a missing/corrupt run-storage error
-// surfaces as a structured fail() rather than escaping to main().catch.
+// Apply the B8 referential-integrity check to a worker output. Returns
+// `{ ok: true }` for no-op (output isn't a trim shape) or for a clean
+// pass; returns `{ ok: false, message, details }` on any violation
+// (env unreadable, schema-cross-ref violations). The --continue caller
+// is responsible for converting `ok: false` to a fail() so the runner
+// stays the only place that touches process.exit; unit tests can drive
+// this function without process.exit by stubbing the env loader and
+// inspecting the return shape.
+//
 // Exported so unit tests can pin the gate without a live FSM run.
-export function runTrimValidationGate(runId, outputs) {
-  if (!outputs || !Array.isArray(outputs.picked_leaves)) return;
+// `_deps` is an optional injection seam (resolveStorageRoot, runEnv,
+// repoRoot) so tests can drive both happy and failure paths.
+export function runTrimValidationGate(runId, outputs, _deps = {}) {
+  if (!outputs || !Array.isArray(outputs.picked_leaves)) return { ok: true };
+  const resolveStorageRootFn = _deps.resolveStorageRoot ?? resolveStorageRoot;
+  const runEnvFn = _deps.runEnv ?? runEnv;
+  const repoRoot = _deps.repoRoot ?? REPO_ROOT;
   let env;
   try {
-    const storageRoot = resolveStorageRoot();
-    env = runEnv(runId, { storageRoot });
+    const storageRoot = resolveStorageRootFn();
+    env = runEnvFn(runId, { storageRoot });
   } catch (err) {
     // Build the parenthetical from defined parts only so we don't emit
-    // awkward strings like "( something)" or "(undefined ...)" when the
-    // thrown value lacks `code` or `message`. Falls back to the
-    // stringified value when neither is present.
+    // awkward strings like "( something)" when the thrown value lacks
+    // `code` or `message`. Falls back to the stringified value when
+    // neither is present.
     const parts = [err?.code, err?.message ?? (typeof err === "string" ? err : null)].filter(
       (p) => typeof p === "string" && p.length > 0,
     );
     const detail = parts.length > 0 ? ` (${parts.join(": ")})` : "";
-    fail(`llm_trim validation: failed to read run env${detail}.`, {
-      state: "llm_trim",
-      run_id: runId,
-    });
+    return {
+      ok: false,
+      message: `llm_trim validation: failed to read run env${detail}.`,
+      details: { state: "llm_trim", run_id: runId },
+    };
   }
-  const v = validateTrimOutput(outputs, env, { repoRoot: REPO_ROOT });
+  const v = validateTrimOutput(outputs, env, { repoRoot });
   if (!v.ok) {
-    fail(
-      `llm_trim referential-integrity validation failed: ${v.errors.join("; ")}`,
-      { state: "llm_trim", violations: v.errors },
-    );
+    return {
+      ok: false,
+      message: `llm_trim referential-integrity validation failed: ${v.errors.join("; ")}`,
+      details: { state: "llm_trim", violations: v.errors },
+    };
   }
+  return { ok: true };
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -490,7 +502,10 @@ async function main() {
     // shape; the trim worker can fabricate ids / paths / files that pass
     // the schema but break downstream consumers. Abort here on any
     // violation rather than let a bad trim output corrupt the env.
-    runTrimValidationGate(runId, outputs);
+    const gate = runTrimValidationGate(runId, outputs);
+    if (!gate.ok) {
+      fail(gate.message, gate.details);
+    }
 
     const commit = runFsmCommit({ runId, outputs });
     if (!commit.ok) {

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -34,7 +34,7 @@ import { dirname, join, resolve } from "node:path";
 import { tmpdir, platform } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { loadConfig, resolveSettings, runEnv } from "@ctxr/fsm";
+import { resolveSettings, runEnv } from "@ctxr/fsm";
 
 import { validateTrimOutput } from "./lib/trim-output-validator.mjs";
 
@@ -78,9 +78,12 @@ const REPO_ROOT = resolve(__dirname, "..");
 const INLINE_STATES_DIR = resolve(__dirname, "inline-states");
 
 function resolveStorageRoot() {
-  const config = loadConfig({ cwd: REPO_ROOT });
-  const settings = resolveSettings(config, { fsmName: "code-reviewer" });
-  return resolve(REPO_ROOT, settings.storage_root);
+  // @ctxr/fsm exposes resolveSettings(cliArgs, cwd) — cliArgs is the
+  // selector ({fsmName, fsmPath, ...}), cwd resolves .fsmrc.json.
+  // resolveSettings calls loadConfig internally; the caller does NOT
+  // pre-load. Returns { fsmPath, storageRoot, ... } in camelCase.
+  const settings = resolveSettings({ fsmName: "code-reviewer" }, REPO_ROOT);
+  return resolve(REPO_ROOT, settings.storageRoot);
 }
 
 export function parseArgs(argv) {

--- a/tests/unit/run-review.test.js
+++ b/tests/unit/run-review.test.js
@@ -12,6 +12,7 @@ import {
   parseFsmCliResult,
   stateIdToModuleName,
   isValidGitRef,
+  runTrimValidationGate,
 } from "../../scripts/run-review.mjs";
 
 test("parseArgs: --flag value pairs become entries", () => {
@@ -125,4 +126,77 @@ test("isValidGitRef: rejects shell metacharacters, leading dash, overlong", () =
   // Length cap (255 chars) — anything longer should be rejected.
   assert.equal(isValidGitRef("a".repeat(256)), false);
   assert.equal(isValidGitRef("a".repeat(255)), true);
+});
+
+test("runTrimValidationGate: no-op for non-trim outputs", () => {
+  // Non-trim worker outputs (no picked_leaves[]) must short-circuit
+  // without calling resolveStorageRoot/runEnv. The injection seam lets
+  // us assert nothing was reached without spinning up the FSM.
+  let called = false;
+  const result = runTrimValidationGate("run-1", { stage_a_candidates: [] }, {
+    resolveStorageRoot: () => { called = true; return "/tmp"; },
+    runEnv: () => { called = true; return {}; },
+  });
+  assert.deepEqual(result, { ok: true });
+  assert.equal(called, false, "no-op path must not touch the env loaders");
+});
+
+test("runTrimValidationGate: aborts when runEnv throws", () => {
+  const err = Object.assign(new Error("run state not found"), { code: "ENOENT" });
+  const result = runTrimValidationGate(
+    "run-1",
+    { picked_leaves: [{ id: "x", path: "x.md" }] },
+    {
+      resolveStorageRoot: () => "/tmp",
+      runEnv: () => { throw err; },
+    },
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.message, /failed to read run env/);
+  assert.match(result.message, /ENOENT/);
+  assert.equal(result.details.state, "llm_trim");
+  assert.equal(result.details.run_id, "run-1");
+});
+
+test("runTrimValidationGate: aborts on validation errors with violation details", () => {
+  // A picked-leaf id that isn't in the wiki triggers class-1; with
+  // injected env carrying empty stage_a_candidates the validator hits
+  // every applicable rule. We pass `repoRoot` to a path with no
+  // reviewers.wiki/ to short-circuit class-2 fully.
+  const result = runTrimValidationGate(
+    "run-1",
+    {
+      picked_leaves: [{ id: "fake-id-not-in-wiki", path: "made-up.md" }],
+      rejected_leaves: [],
+      coverage_rescues: [],
+    },
+    {
+      resolveStorageRoot: () => "/tmp",
+      runEnv: () => ({ stage_a_candidates: [], changed_paths: [] }),
+      repoRoot: "/this/path/has/no/reviewers/wiki/at/all",
+    },
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.message, /referential-integrity validation failed/);
+  assert.equal(result.details.state, "llm_trim");
+  assert.ok(Array.isArray(result.details.violations));
+  assert.ok(result.details.violations.length > 0);
+});
+
+test("runTrimValidationGate: clean trim output passes", () => {
+  // A trim output whose picked leaf matches stage_a_candidates by
+  // {id, path} and resolves to a wiki file we don't have on disk
+  // (path-resolution is class 2) should report a class-2 violation but
+  // not crash. We're just asserting the happy path returns an `ok`
+  // shape without throwing — the validator's correctness is covered by
+  // its own test suite.
+  const result = runTrimValidationGate(
+    "run-1",
+    null, // null is treated as no-op
+    {
+      resolveStorageRoot: () => "/tmp",
+      runEnv: () => ({}),
+    },
+  );
+  assert.deepEqual(result, { ok: true });
 });

--- a/tests/unit/run-review.test.js
+++ b/tests/unit/run-review.test.js
@@ -179,20 +179,22 @@ test("runTrimValidationGate: aborts on validation errors with violation details"
   assert.equal(result.ok, false);
   assert.match(result.message, /referential-integrity validation failed/);
   assert.equal(result.details.state, "llm_trim");
+  assert.equal(result.details.run_id, "run-1", "run_id must be present in validation-failure details for fault-trace correlation");
   assert.ok(Array.isArray(result.details.violations));
   assert.ok(result.details.violations.length > 0);
 });
 
-test("runTrimValidationGate: clean trim output passes", () => {
-  // A trim output whose picked leaf matches stage_a_candidates by
-  // {id, path} and resolves to a wiki file we don't have on disk
-  // (path-resolution is class 2) should report a class-2 violation but
-  // not crash. We're just asserting the happy path returns an `ok`
-  // shape without throwing — the validator's correctness is covered by
-  // its own test suite.
+test("runTrimValidationGate: null outputs treated as no-op (gate doesn't fire)", () => {
+  // The gate only validates outputs that look like trim output. `null`
+  // is the explicit no-op input — the runner can call this gate from
+  // every --continue without first sniffing the worker's identity, and
+  // anything that isn't a trim shape (including null/undefined or a
+  // different worker's payload) falls through without touching the env
+  // loaders. The validator's own correctness is covered by its
+  // dedicated test suite.
   const result = runTrimValidationGate(
     "run-1",
-    null, // null is treated as no-op
+    null,
     {
       resolveStorageRoot: () => "/tmp",
       runEnv: () => ({}),

--- a/tests/unit/trim-output-validator.test.js
+++ b/tests/unit/trim-output-validator.test.js
@@ -46,6 +46,10 @@ before(() => {
   writeLeaf(HERMETIC_REPO_ROOT, "cluster-a/fake-lang.md", "fake-lang");
   writeLeaf(HERMETIC_REPO_ROOT, "cluster-b/fake-sec.md", "fake-sec");
   writeLeaf(HERMETIC_REPO_ROOT, "cluster-b/fake-rejected.md", "fake-rejected");
+  // Second copy of fake-lang under cluster-b/ so the duplicate-stage-A
+  // test can pick a real, on-disk leaf and exercise class 3 alone (not
+  // accidentally fail on class 2 because the file doesn't exist).
+  writeLeaf(HERMETIC_REPO_ROOT, "cluster-b/fake-lang.md", "fake-lang");
 });
 
 after(() => {
@@ -227,7 +231,7 @@ test("validateTrimOutput: pair check accepts cosmetic 'reviewers.wiki/' prefix o
   };
   const result = validateTrimOutput(out, env, hermeticOpts());
   const class3Errors = result.errors.filter((e) =>
-    e.includes("not in stage_a_candidates") || e.includes("does not match stage_a_candidates entry path"),
+    e.includes("not in stage_a_candidates") || e.includes("does not match any stage_a_candidates entry path"),
   );
   assert.deepEqual(class3Errors, [], `prefix-normalized paths must not trigger class 3: ${result.errors.join("; ")}`);
 });

--- a/tests/unit/trim-output-validator.test.js
+++ b/tests/unit/trim-output-validator.test.js
@@ -86,7 +86,77 @@ test("validateTrimOutput: rejects picked_leaves[].path that doesn't resolve (cla
   );
 });
 
-test("validateTrimOutput: rejects rejected_leaves[].id not in stage_a_candidates (class 3)", () => {
+test("validateTrimOutput: rejects picked_leaves not in stage_a_candidates (class 3, id mismatch)", () => {
+  // sec-csrf is a real wiki id and resolves to a real file — but it is NOT
+  // in stage_a_candidates for this scenario. Class 1 + class 2 must both
+  // pass; class 3 is the only thing catching this fabrication.
+  const env = {
+    stage_a_candidates: [
+      { id: "lang-typescript", path: "formatter-eslint/lang-typescript.md" },
+    ],
+    changed_paths: [],
+  };
+  const out = {
+    picked_leaves: [
+      { id: "sec-csrf", path: "csrf-missing/sec-csrf.md", justification: "x", dimensions: [] },
+    ],
+    rejected_leaves: [],
+    coverage_rescues: [],
+  };
+  const result = validateTrimOutput(out, env, { knownLeafIds: KNOWN_IDS });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some(
+      (e) => e.includes("sec-csrf") && e.includes("not in stage_a_candidates"),
+    ),
+    `expected a stage-A-candidate membership error, got: ${result.errors.join("; ")}`,
+  );
+});
+
+test("validateTrimOutput: rejects picked_leaves with wrong path for the id (class 3, path mismatch)", () => {
+  // Both id (lang-typescript) and path (csrf-missing/sec-csrf.md) are
+  // individually valid wiki entries, but the pair doesn't match: stage_a
+  // declared lang-typescript at formatter-eslint/lang-typescript.md.
+  // Without the pair check, the worker could split id/path across two real
+  // leaves and bypass downstream coverage scoping.
+  const out = validOutputs();
+  out.picked_leaves[0].path = "csrf-missing/sec-csrf.md";
+  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some(
+      (e) => e.includes("lang-typescript") && e.includes("does not match stage_a_candidates entry path"),
+    ),
+    `expected an id↔path pair-mismatch error, got: ${result.errors.join("; ")}`,
+  );
+});
+
+test("validateTrimOutput: pair check accepts cosmetic 'reviewers.wiki/' prefix on stage_a path", () => {
+  // Stage-A may emit either wiki-relative or repo-relative paths;
+  // normalizeWikiPath collapses them. Same effective path must match.
+  const env = {
+    stage_a_candidates: [
+      { id: "lang-typescript", path: "reviewers.wiki/formatter-eslint/lang-typescript.md" },
+    ],
+    changed_paths: [],
+  };
+  const out = {
+    picked_leaves: [
+      { id: "lang-typescript", path: "formatter-eslint/lang-typescript.md", justification: "x", dimensions: [] },
+    ],
+    rejected_leaves: [],
+    coverage_rescues: [],
+  };
+  const result = validateTrimOutput(out, env, { knownLeafIds: KNOWN_IDS });
+  // Class 2 may still fail if the file isn't on disk (the test uses a real
+  // path), but class 3's pair check must NOT contribute an error here.
+  const class3Errors = result.errors.filter((e) =>
+    e.includes("not in stage_a_candidates") || e.includes("does not match stage_a_candidates entry path"),
+  );
+  assert.deepEqual(class3Errors, [], `prefix-normalized paths must not trigger class 3: ${result.errors.join("; ")}`);
+});
+
+test("validateTrimOutput: rejects rejected_leaves[].id not in stage_a_candidates (class 4)", () => {
   const out = validOutputs();
   out.rejected_leaves.push({ id: "phantom-rejected", reason: "?" });
   const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
@@ -99,7 +169,7 @@ test("validateTrimOutput: rejects rejected_leaves[].id not in stage_a_candidates
   );
 });
 
-test("validateTrimOutput: rejects coverage_rescues[].file not in changed_paths (class 4)", () => {
+test("validateTrimOutput: rejects coverage_rescues[].file not in changed_paths (class 5)", () => {
   const out = validOutputs();
   out.coverage_rescues[0].file = "not-in-the-diff.ts";
   const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
@@ -112,7 +182,7 @@ test("validateTrimOutput: rejects coverage_rescues[].file not in changed_paths (
   );
 });
 
-test("validateTrimOutput: rejects coverage_rescues[].rescued_leaf not in rejected_leaves (class 5)", () => {
+test("validateTrimOutput: rejects coverage_rescues[].rescued_leaf not in rejected_leaves (class 6)", () => {
   const out = validOutputs();
   out.coverage_rescues[0].rescued_leaf = "leaf-the-trim-worker-imagined";
   const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });

--- a/tests/unit/trim-output-validator.test.js
+++ b/tests/unit/trim-output-validator.test.js
@@ -111,6 +111,32 @@ test("validateTrimOutput: rejects picked_leaves[].path that doesn't resolve (cla
   );
 });
 
+test("validateTrimOutput: class 2 rejects non-leaf wiki paths (index.md, dotfiles, non-md)", () => {
+  // A path that resolves to a real file under reviewers.wiki/ but isn't
+  // a leaf (cluster index, dotfile, non-markdown) must NOT pass class 2.
+  // Without this, a worker could fabricate
+  // `picked_leaves[].path = "cluster-a/index.md"` and bypass the gate.
+  const indexPath = join(HERMETIC_REPO_ROOT, "reviewers.wiki", "cluster-a", "index.md");
+  const dotPath = join(HERMETIC_REPO_ROOT, "reviewers.wiki", "cluster-a", ".gitignore");
+  const txtPath = join(HERMETIC_REPO_ROOT, "reviewers.wiki", "cluster-a", "notes.txt");
+  writeFileSync(indexPath, "---\nid: index\ntype: cluster\n---\n");
+  writeFileSync(dotPath, "");
+  writeFileSync(txtPath, "scratch");
+  for (const badPath of ["cluster-a/index.md", "cluster-a/.gitignore", "cluster-a/notes.txt"]) {
+    const out = {
+      picked_leaves: [{ id: "fake-lang", path: badPath, justification: "x", dimensions: [] }],
+      rejected_leaves: [],
+      coverage_rescues: [],
+    };
+    const result = validateTrimOutput(out, VALID_ENV, hermeticOpts());
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.errors.some((e) => e.includes("does not resolve to a real wiki file")),
+      `expected class-2 rejection for non-leaf path "${badPath}", got: ${result.errors.join("; ")}`,
+    );
+  }
+});
+
 test("validateTrimOutput: rejects picked_leaves not in stage_a_candidates (class 3, id mismatch)", () => {
   // fake-sec is a real wiki id and resolves to a real file — but it is NOT
   // in stage_a_candidates for this scenario. Class 1 + class 2 must both

--- a/tests/unit/trim-output-validator.test.js
+++ b/tests/unit/trim-output-validator.test.js
@@ -174,10 +174,39 @@ test("validateTrimOutput: rejects picked_leaves with wrong path for the id (clas
   assert.equal(result.ok, false);
   assert.ok(
     result.errors.some(
-      (e) => e.includes("fake-lang") && e.includes("does not match stage_a_candidates entry path"),
+      (e) => e.includes("fake-lang") && e.includes("does not match any stage_a_candidates entry path"),
     ),
     `expected an id↔path pair-mismatch error, got: ${result.errors.join("; ")}`,
   );
+});
+
+test("validateTrimOutput: pair check is order-independent under duplicate stage_a ids", () => {
+  // stage_a_candidates is a list, not a map. The same id may legitimately
+  // appear with multiple paths. The pair check must accept ANY declared
+  // {id, path} pair — a Map keyed only by id would have been
+  // order-dependent (last write wins) and could mis-match a picked leaf
+  // against the wrong path.
+  const env = {
+    stage_a_candidates: [
+      { id: "fake-lang", path: "cluster-a/fake-lang.md" },
+      { id: "fake-lang", path: "cluster-b/fake-lang.md" },
+    ],
+    changed_paths: [],
+  };
+  // Picking the SECOND declared path must pass even though a Map keyed
+  // only by id would have remembered the first.
+  const out = {
+    picked_leaves: [
+      { id: "fake-lang", path: "cluster-b/fake-lang.md", justification: "x", dimensions: [] },
+    ],
+    rejected_leaves: [],
+    coverage_rescues: [],
+  };
+  const result = validateTrimOutput(out, env, hermeticOpts());
+  const class3Errors = result.errors.filter((e) =>
+    e.includes("not in stage_a_candidates") || e.includes("does not match"),
+  );
+  assert.deepEqual(class3Errors, [], `duplicate stage_a id pair check must succeed: ${result.errors.join("; ")}`);
 });
 
 test("validateTrimOutput: pair check accepts cosmetic 'reviewers.wiki/' prefix on stage_a path", () => {

--- a/tests/unit/trim-output-validator.test.js
+++ b/tests/unit/trim-output-validator.test.js
@@ -11,7 +11,7 @@
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { validateTrimOutput } from "../../scripts/lib/trim-output-validator.mjs";
@@ -34,7 +34,7 @@ let HERMETIC_REPO_ROOT;
 
 function writeLeaf(repoRoot, relPath, id) {
   const abs = join(repoRoot, "reviewers.wiki", relPath);
-  mkdirSync(join(abs, ".."), { recursive: true });
+  mkdirSync(dirname(abs), { recursive: true });
   writeFileSync(
     abs,
     `---\nid: ${id}\ntype: leaf\n---\n\n# ${id}\n`,

--- a/tests/unit/trim-output-validator.test.js
+++ b/tests/unit/trim-output-validator.test.js
@@ -1,10 +1,16 @@
 // Tests for the B8 referential-integrity validator. Each violation class
 // gets its own fixture; the validator must surface a specific error per
 // class, and a fully-valid fixture must produce { ok: true, errors: [] }.
+//
+// Hermetic by construction: the test suite builds a synthetic
+// reviewers.wiki/ tree under a per-test-process temp directory and runs
+// every assertion against that. No assumption about which leaf ids the
+// real corpus carries today — wiki reorganizations / renames don't break
+// this suite.
 
-import { test } from "node:test";
+import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -21,19 +27,36 @@ if (existsSync(NONEXISTENT_REPO_ROOT)) {
   throw new Error("test setup failed: NONEXISTENT_REPO_ROOT still exists");
 }
 
-// Use real wiki ids + paths so the file-resolution check (class 2) doesn't
-// false-fail the valid fixture. lang-typescript is committed at
-// reviewers.wiki/formatter-eslint/lang-typescript.md; sec-csrf and
-// sec-idor-and-mass-assignment live under reviewers.wiki/csrf-missing/.
-// Picking three real leaves keeps the fixture self-contained and
-// independent of the wiki's ongoing growth.
-const KNOWN_IDS = ["lang-typescript", "sec-csrf", "sec-idor-and-mass-assignment"];
+// Synthetic wiki: 3 leaves under deterministic paths. Using made-up ids
+// (`fake-lang`, `fake-sec`, `fake-rejected`) keeps the assertions
+// independent of the real corpus.
+let HERMETIC_REPO_ROOT;
+
+function writeLeaf(repoRoot, relPath, id) {
+  const abs = join(repoRoot, "reviewers.wiki", relPath);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(
+    abs,
+    `---\nid: ${id}\ntype: leaf\n---\n\n# ${id}\n`,
+  );
+}
+
+before(() => {
+  HERMETIC_REPO_ROOT = mkdtempSync(join(tmpdir(), "trim-validator-hermetic-"));
+  writeLeaf(HERMETIC_REPO_ROOT, "cluster-a/fake-lang.md", "fake-lang");
+  writeLeaf(HERMETIC_REPO_ROOT, "cluster-b/fake-sec.md", "fake-sec");
+  writeLeaf(HERMETIC_REPO_ROOT, "cluster-b/fake-rejected.md", "fake-rejected");
+});
+
+after(() => {
+  if (HERMETIC_REPO_ROOT) rmSync(HERMETIC_REPO_ROOT, { recursive: true, force: true });
+});
 
 const VALID_ENV = {
   stage_a_candidates: [
-    { id: "lang-typescript", path: "formatter-eslint/lang-typescript.md", activation_match: ["file_globs"] },
-    { id: "sec-csrf", path: "csrf-missing/sec-csrf.md", activation_match: ["file_globs"] },
-    { id: "sec-idor-and-mass-assignment", path: "csrf-missing/sec-idor-and-mass-assignment.md", activation_match: ["file_globs"] },
+    { id: "fake-lang", path: "cluster-a/fake-lang.md", activation_match: ["file_globs"] },
+    { id: "fake-sec", path: "cluster-b/fake-sec.md", activation_match: ["file_globs"] },
+    { id: "fake-rejected", path: "cluster-b/fake-rejected.md", activation_match: ["file_globs"] },
   ],
   changed_paths: ["src/api/auth.ts", "src/util/jwt.ts"],
 };
@@ -41,25 +64,29 @@ const VALID_ENV = {
 function validOutputs() {
   return {
     picked_leaves: [
-      { id: "lang-typescript", path: "formatter-eslint/lang-typescript.md", justification: "ok", dimensions: ["correctness"] },
-      { id: "sec-csrf", path: "csrf-missing/sec-csrf.md", justification: "ok", dimensions: ["security"] },
+      { id: "fake-lang", path: "cluster-a/fake-lang.md", justification: "ok", dimensions: ["correctness"] },
+      { id: "fake-sec", path: "cluster-b/fake-sec.md", justification: "ok", dimensions: ["security"] },
     ],
-    rejected_leaves: [{ id: "sec-idor-and-mass-assignment", reason: "low signal" }],
+    rejected_leaves: [{ id: "fake-rejected", reason: "low signal" }],
     coverage_rescues: [
-      { file: "src/api/auth.ts", rescued_leaf: "sec-idor-and-mass-assignment", reason: "rescue" },
+      { file: "src/api/auth.ts", rescued_leaf: "fake-rejected", reason: "rescue" },
     ],
   };
 }
 
+function hermeticOpts(extra = {}) {
+  return { repoRoot: HERMETIC_REPO_ROOT, ...extra };
+}
+
 test("validateTrimOutput: a fully-valid fixture passes", () => {
-  const result = validateTrimOutput(validOutputs(), VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  const result = validateTrimOutput(validOutputs(), VALID_ENV, hermeticOpts());
   assert.deepEqual(result, { ok: true, errors: [] });
 });
 
 test("validateTrimOutput: rejects picked_leaves[].id not in wiki (class 1)", () => {
   const out = validOutputs();
   out.picked_leaves[0].id = "nonexistent-leaf-id";
-  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  const result = validateTrimOutput(out, VALID_ENV, hermeticOpts());
   assert.equal(result.ok, false);
   assert.ok(
     result.errors.some((e) => e.includes("nonexistent-leaf-id") && e.includes("reviewers.wiki")),
@@ -71,14 +98,12 @@ test("validateTrimOutput: rejects picked_leaves[].path that doesn't resolve (cla
   const out = validOutputs();
   out.picked_leaves[0].path = "made-up/does-not-exist.md";
   const result = validateTrimOutput(out, VALID_ENV, {
-    knownLeafIds: KNOWN_IDS,
     repoRoot: NONEXISTENT_REPO_ROOT,
+    knownLeafIds: ["fake-lang", "fake-sec", "fake-rejected"],
   });
-  // `knownLeafIds` short-circuits the class-1 wiki walk (the validator
-  // accepts the explicit allow-list as the source of truth), so this
-  // case targets the class-2 path-resolution check exclusively. With a
-  // nonexistent repo root, every wiki-path resolution must fail and
-  // surface a "does not resolve to a real wiki file" error.
+  // knownLeafIds short-circuits class 1 (the validator accepts the
+  // explicit allow-list as the source of truth); the nonexistent
+  // repo root drives every wiki-path resolution to fail (class 2).
   assert.equal(result.ok, false);
   assert.ok(
     result.errors.some((e) => e.includes("does not resolve to a real wiki file")),
@@ -87,45 +112,43 @@ test("validateTrimOutput: rejects picked_leaves[].path that doesn't resolve (cla
 });
 
 test("validateTrimOutput: rejects picked_leaves not in stage_a_candidates (class 3, id mismatch)", () => {
-  // sec-csrf is a real wiki id and resolves to a real file — but it is NOT
+  // fake-sec is a real wiki id and resolves to a real file — but it is NOT
   // in stage_a_candidates for this scenario. Class 1 + class 2 must both
   // pass; class 3 is the only thing catching this fabrication.
   const env = {
     stage_a_candidates: [
-      { id: "lang-typescript", path: "formatter-eslint/lang-typescript.md" },
+      { id: "fake-lang", path: "cluster-a/fake-lang.md" },
     ],
     changed_paths: [],
   };
   const out = {
     picked_leaves: [
-      { id: "sec-csrf", path: "csrf-missing/sec-csrf.md", justification: "x", dimensions: [] },
+      { id: "fake-sec", path: "cluster-b/fake-sec.md", justification: "x", dimensions: [] },
     ],
     rejected_leaves: [],
     coverage_rescues: [],
   };
-  const result = validateTrimOutput(out, env, { knownLeafIds: KNOWN_IDS });
+  const result = validateTrimOutput(out, env, hermeticOpts());
   assert.equal(result.ok, false);
   assert.ok(
     result.errors.some(
-      (e) => e.includes("sec-csrf") && e.includes("not in stage_a_candidates"),
+      (e) => e.includes("fake-sec") && e.includes("not in stage_a_candidates"),
     ),
     `expected a stage-A-candidate membership error, got: ${result.errors.join("; ")}`,
   );
 });
 
 test("validateTrimOutput: rejects picked_leaves with wrong path for the id (class 3, path mismatch)", () => {
-  // Both id (lang-typescript) and path (csrf-missing/sec-csrf.md) are
-  // individually valid wiki entries, but the pair doesn't match: stage_a
-  // declared lang-typescript at formatter-eslint/lang-typescript.md.
-  // Without the pair check, the worker could split id/path across two real
-  // leaves and bypass downstream coverage scoping.
+  // Both id (fake-lang) and path (cluster-b/fake-sec.md) are individually
+  // valid wiki entries, but the pair doesn't match: stage_a declared
+  // fake-lang at cluster-a/fake-lang.md.
   const out = validOutputs();
-  out.picked_leaves[0].path = "csrf-missing/sec-csrf.md";
-  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  out.picked_leaves[0].path = "cluster-b/fake-sec.md";
+  const result = validateTrimOutput(out, VALID_ENV, hermeticOpts());
   assert.equal(result.ok, false);
   assert.ok(
     result.errors.some(
-      (e) => e.includes("lang-typescript") && e.includes("does not match stage_a_candidates entry path"),
+      (e) => e.includes("fake-lang") && e.includes("does not match stage_a_candidates entry path"),
     ),
     `expected an id↔path pair-mismatch error, got: ${result.errors.join("; ")}`,
   );
@@ -136,20 +159,18 @@ test("validateTrimOutput: pair check accepts cosmetic 'reviewers.wiki/' prefix o
   // normalizeWikiPath collapses them. Same effective path must match.
   const env = {
     stage_a_candidates: [
-      { id: "lang-typescript", path: "reviewers.wiki/formatter-eslint/lang-typescript.md" },
+      { id: "fake-lang", path: "reviewers.wiki/cluster-a/fake-lang.md" },
     ],
     changed_paths: [],
   };
   const out = {
     picked_leaves: [
-      { id: "lang-typescript", path: "formatter-eslint/lang-typescript.md", justification: "x", dimensions: [] },
+      { id: "fake-lang", path: "cluster-a/fake-lang.md", justification: "x", dimensions: [] },
     ],
     rejected_leaves: [],
     coverage_rescues: [],
   };
-  const result = validateTrimOutput(out, env, { knownLeafIds: KNOWN_IDS });
-  // Class 2 may still fail if the file isn't on disk (the test uses a real
-  // path), but class 3's pair check must NOT contribute an error here.
+  const result = validateTrimOutput(out, env, hermeticOpts());
   const class3Errors = result.errors.filter((e) =>
     e.includes("not in stage_a_candidates") || e.includes("does not match stage_a_candidates entry path"),
   );
@@ -159,7 +180,7 @@ test("validateTrimOutput: pair check accepts cosmetic 'reviewers.wiki/' prefix o
 test("validateTrimOutput: rejects rejected_leaves[].id not in stage_a_candidates (class 4)", () => {
   const out = validOutputs();
   out.rejected_leaves.push({ id: "phantom-rejected", reason: "?" });
-  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  const result = validateTrimOutput(out, VALID_ENV, hermeticOpts());
   assert.equal(result.ok, false);
   assert.ok(
     result.errors.some(
@@ -172,7 +193,7 @@ test("validateTrimOutput: rejects rejected_leaves[].id not in stage_a_candidates
 test("validateTrimOutput: rejects coverage_rescues[].file not in changed_paths (class 5)", () => {
   const out = validOutputs();
   out.coverage_rescues[0].file = "not-in-the-diff.ts";
-  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  const result = validateTrimOutput(out, VALID_ENV, hermeticOpts());
   assert.equal(result.ok, false);
   assert.ok(
     result.errors.some(
@@ -185,7 +206,7 @@ test("validateTrimOutput: rejects coverage_rescues[].file not in changed_paths (
 test("validateTrimOutput: rejects coverage_rescues[].rescued_leaf not in rejected_leaves (class 6)", () => {
   const out = validOutputs();
   out.coverage_rescues[0].rescued_leaf = "leaf-the-trim-worker-imagined";
-  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  const result = validateTrimOutput(out, VALID_ENV, hermeticOpts());
   assert.equal(result.ok, false);
   assert.ok(
     result.errors.some(
@@ -204,30 +225,24 @@ test("validateTrimOutput: collects ALL violations in a single pass (multi-class)
       { file: "not-in-diff.ts", rescued_leaf: "leaf-the-trim-worker-imagined", reason: "?" },
     ],
   };
-  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  const result = validateTrimOutput(out, VALID_ENV, hermeticOpts());
   assert.equal(result.ok, false);
-  // Expect at least 5 errors (one per class). Path check may add one more.
   assert.ok(result.errors.length >= 5, `expected ≥5 errors, got ${result.errors.length}: ${result.errors.join("; ")}`);
 });
 
 test("validateTrimOutput: non-trim output (no picked_leaves) is a no-op", () => {
-  // The validator only fires for outputs that look like trim output. A
-  // shape-mismatch from another worker should not raise spurious errors.
-  const result = validateTrimOutput({ stage_a_candidates: [] }, VALID_ENV, {
-    knownLeafIds: KNOWN_IDS,
-  });
+  const result = validateTrimOutput({ stage_a_candidates: [] }, VALID_ENV, hermeticOpts());
   assert.deepEqual(result, { ok: true, errors: [] });
 });
 
 test("validateTrimOutput: missing fields on a trim output produce specific errors", () => {
   const out = {
-    picked_leaves: [{}, { id: "sec-jwt-tokens" }], // missing id, missing path
+    picked_leaves: [{}, { id: "fake-other" }], // missing id, missing path
     rejected_leaves: [{}],
     coverage_rescues: [{}],
   };
-  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  const result = validateTrimOutput(out, VALID_ENV, hermeticOpts());
   assert.equal(result.ok, false);
-  // "missing string `id`" hits picked_leaves and rejected_leaves; "missing string `file`" / `rescued_leaf` hit coverage_rescues; path missing on the second picked leaf.
   const joined = result.errors.join(" || ");
   assert.match(joined, /missing string `id`/);
   assert.match(joined, /missing or not a string|does not resolve/);

--- a/tests/unit/trim-output-validator.test.js
+++ b/tests/unit/trim-output-validator.test.js
@@ -4,8 +4,22 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 import { validateTrimOutput } from "../../scripts/lib/trim-output-validator.mjs";
+
+// Reserve a portable, definitely-empty repo root for tests that need a
+// repoRoot which does NOT contain reviewers.wiki/. mkdtempSync + rmSync
+// gives a path that's guaranteed unique AND not on disk — works on
+// Windows + POSIX, and never collides with an existing tree.
+const _t = mkdtempSync(join(tmpdir(), "trim-validator-no-wiki-"));
+rmSync(_t, { recursive: true, force: true });
+const NONEXISTENT_REPO_ROOT = _t;
+if (existsSync(NONEXISTENT_REPO_ROOT)) {
+  throw new Error("test setup failed: NONEXISTENT_REPO_ROOT still exists");
+}
 
 // Use real wiki ids + paths so the file-resolution check (class 2) doesn't
 // false-fail the valid fixture. lang-typescript is committed at
@@ -58,7 +72,7 @@ test("validateTrimOutput: rejects picked_leaves[].path that doesn't resolve (cla
   out.picked_leaves[0].path = "made-up/does-not-exist.md";
   const result = validateTrimOutput(out, VALID_ENV, {
     knownLeafIds: KNOWN_IDS,
-    repoRoot: "/tmp/nonexistent-repo-root-for-test",
+    repoRoot: NONEXISTENT_REPO_ROOT,
   });
   // `knownLeafIds` short-circuits the class-1 wiki walk (the validator
   // accepts the explicit allow-list as the source of truth), so this

--- a/tests/unit/trim-output-validator.test.js
+++ b/tests/unit/trim-output-validator.test.js
@@ -1,0 +1,151 @@
+// Tests for the B8 referential-integrity validator. Each violation class
+// gets its own fixture; the validator must surface a specific error per
+// class, and a fully-valid fixture must produce { ok: true, errors: [] }.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { validateTrimOutput } from "../../scripts/lib/trim-output-validator.mjs";
+
+// Use real wiki ids + paths so the file-resolution check (class 2) doesn't
+// false-fail the valid fixture. lang-typescript is committed at
+// reviewers.wiki/formatter-eslint/lang-typescript.md; sec-csrf and
+// sec-idor-and-mass-assignment live under reviewers.wiki/csrf-missing/.
+// Picking three real leaves keeps the fixture self-contained and
+// independent of the wiki's ongoing growth.
+const KNOWN_IDS = ["lang-typescript", "sec-csrf", "sec-idor-and-mass-assignment"];
+
+const VALID_ENV = {
+  stage_a_candidates: [
+    { id: "lang-typescript", path: "formatter-eslint/lang-typescript.md", activation_match: ["file_globs"] },
+    { id: "sec-csrf", path: "csrf-missing/sec-csrf.md", activation_match: ["file_globs"] },
+    { id: "sec-idor-and-mass-assignment", path: "csrf-missing/sec-idor-and-mass-assignment.md", activation_match: ["file_globs"] },
+  ],
+  changed_paths: ["src/api/auth.ts", "src/util/jwt.ts"],
+};
+
+function validOutputs() {
+  return {
+    picked_leaves: [
+      { id: "lang-typescript", path: "formatter-eslint/lang-typescript.md", justification: "ok", dimensions: ["correctness"] },
+      { id: "sec-csrf", path: "csrf-missing/sec-csrf.md", justification: "ok", dimensions: ["security"] },
+    ],
+    rejected_leaves: [{ id: "sec-idor-and-mass-assignment", reason: "low signal" }],
+    coverage_rescues: [
+      { file: "src/api/auth.ts", rescued_leaf: "sec-idor-and-mass-assignment", reason: "rescue" },
+    ],
+  };
+}
+
+test("validateTrimOutput: a fully-valid fixture passes", () => {
+  const result = validateTrimOutput(validOutputs(), VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  assert.deepEqual(result, { ok: true, errors: [] });
+});
+
+test("validateTrimOutput: rejects picked_leaves[].id not in wiki (class 1)", () => {
+  const out = validOutputs();
+  out.picked_leaves[0].id = "nonexistent-leaf-id";
+  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some((e) => e.includes("nonexistent-leaf-id") && e.includes("reviewers.wiki")),
+    "expected an error mentioning the fabricated id and wiki",
+  );
+});
+
+test("validateTrimOutput: rejects picked_leaves[].path that doesn't resolve (class 2)", () => {
+  const out = validOutputs();
+  out.picked_leaves[0].path = "made-up/does-not-exist.md";
+  const result = validateTrimOutput(out, VALID_ENV, {
+    knownLeafIds: KNOWN_IDS,
+    repoRoot: "/tmp/nonexistent-repo-root-for-test",
+  });
+  // With a nonexistent repo root, BOTH path-check (class 2) and id-set
+  // (class 1, because knownLeafIds short-circuits the wiki walk) come into
+  // play differently. The class-2 check is the targeted one — assert at
+  // least one error mentions the bad path.
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some((e) => e.includes("does not resolve to a real wiki file")),
+    `expected a path-resolution error, got: ${result.errors.join("; ")}`,
+  );
+});
+
+test("validateTrimOutput: rejects rejected_leaves[].id not in stage_a_candidates (class 3)", () => {
+  const out = validOutputs();
+  out.rejected_leaves.push({ id: "phantom-rejected", reason: "?" });
+  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some(
+      (e) => e.includes("phantom-rejected") && e.includes("stage_a_candidates"),
+    ),
+    "expected a stage_a_candidates membership error",
+  );
+});
+
+test("validateTrimOutput: rejects coverage_rescues[].file not in changed_paths (class 4)", () => {
+  const out = validOutputs();
+  out.coverage_rescues[0].file = "not-in-the-diff.ts";
+  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some(
+      (e) => e.includes("not-in-the-diff.ts") && e.includes("changed_paths"),
+    ),
+    "expected a changed_paths membership error",
+  );
+});
+
+test("validateTrimOutput: rejects coverage_rescues[].rescued_leaf not in rejected_leaves (class 5)", () => {
+  const out = validOutputs();
+  out.coverage_rescues[0].rescued_leaf = "leaf-the-trim-worker-imagined";
+  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some(
+      (e) =>
+        e.includes("leaf-the-trim-worker-imagined") && e.includes("rejected_leaves"),
+    ),
+    "expected a rescued_leaf ↔ rejected_leaves[] cross-ref error",
+  );
+});
+
+test("validateTrimOutput: collects ALL violations in a single pass (multi-class)", () => {
+  const out = {
+    picked_leaves: [{ id: "fabricated-id", path: "fabricated.md", justification: "x", dimensions: [] }],
+    rejected_leaves: [{ id: "phantom-rejected", reason: "?" }],
+    coverage_rescues: [
+      { file: "not-in-diff.ts", rescued_leaf: "leaf-the-trim-worker-imagined", reason: "?" },
+    ],
+  };
+  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  assert.equal(result.ok, false);
+  // Expect at least 5 errors (one per class). Path check may add one more.
+  assert.ok(result.errors.length >= 5, `expected ≥5 errors, got ${result.errors.length}: ${result.errors.join("; ")}`);
+});
+
+test("validateTrimOutput: non-trim output (no picked_leaves) is a no-op", () => {
+  // The validator only fires for outputs that look like trim output. A
+  // shape-mismatch from another worker should not raise spurious errors.
+  const result = validateTrimOutput({ stage_a_candidates: [] }, VALID_ENV, {
+    knownLeafIds: KNOWN_IDS,
+  });
+  assert.deepEqual(result, { ok: true, errors: [] });
+});
+
+test("validateTrimOutput: missing fields on a trim output produce specific errors", () => {
+  const out = {
+    picked_leaves: [{}, { id: "sec-jwt-tokens" }], // missing id, missing path
+    rejected_leaves: [{}],
+    coverage_rescues: [{}],
+  };
+  const result = validateTrimOutput(out, VALID_ENV, { knownLeafIds: KNOWN_IDS });
+  assert.equal(result.ok, false);
+  // "missing string `id`" hits picked_leaves and rejected_leaves; "missing string `file`" / `rescued_leaf` hit coverage_rescues; path missing on the second picked leaf.
+  const joined = result.errors.join(" || ");
+  assert.match(joined, /missing string `id`/);
+  assert.match(joined, /missing or not a string|does not resolve/);
+  assert.match(joined, /missing string `file`/);
+  assert.match(joined, /missing string `rescued_leaf`/);
+});

--- a/tests/unit/trim-output-validator.test.js
+++ b/tests/unit/trim-output-validator.test.js
@@ -60,10 +60,11 @@ test("validateTrimOutput: rejects picked_leaves[].path that doesn't resolve (cla
     knownLeafIds: KNOWN_IDS,
     repoRoot: "/tmp/nonexistent-repo-root-for-test",
   });
-  // With a nonexistent repo root, BOTH path-check (class 2) and id-set
-  // (class 1, because knownLeafIds short-circuits the wiki walk) come into
-  // play differently. The class-2 check is the targeted one — assert at
-  // least one error mentions the bad path.
+  // `knownLeafIds` short-circuits the class-1 wiki walk (the validator
+  // accepts the explicit allow-list as the source of truth), so this
+  // case targets the class-2 path-resolution check exclusively. With a
+  // nonexistent repo root, every wiki-path resolution must fail and
+  // surface a "does not resolve to a real wiki file" error.
   assert.equal(result.ok, false);
   assert.ok(
     result.errors.some((e) => e.includes("does not resolve to a real wiki file")),


### PR DESCRIPTION
Sprint B B8 — six referential-integrity checks on the trim worker's output before it enters the run env. Wired into run-review.mjs --continue path; aborts the run on any violation. Tests cover all 6 fabrication classes + multi-violation. Closes #13

Round 4 added a stage-A pair check (picked_leaves[i] must match a stage_a_candidates entry by both id AND path) on top of the original five from #13, so an `{id: real-leaf-A, path: real-leaf-B-path}` fabrication can no longer split id vs path across two valid leaves and bypass downstream coverage scoping.
