### PR TITLE
feat(b7): worker-output record/replay harness (#12)

### DIFF
--- a/scripts/inline-states/write-run-directory.mjs
+++ b/scripts/inline-states/write-run-directory.mjs
@@ -24,7 +24,6 @@ import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
-  loadConfig,
   resolveSettings,
   runDirPath,
   readManifest,
@@ -34,9 +33,13 @@ import {
 import { renderReportMarkdown, renderReportJson } from "../lib/report-renderer.mjs";
 
 function resolveStorageRoot(repoRoot) {
-  const config = loadConfig({ cwd: repoRoot });
-  const settings = resolveSettings(config, { fsmName: "code-reviewer" });
-  return resolve(repoRoot, settings.storage_root);
+  // @ctxr/fsm exposes resolveSettings(cliArgs, cwd) — cliArgs is the
+  // selector ({fsmName, fsmPath, ...}), cwd resolves .fsmrc.json.
+  // resolveSettings calls loadConfig internally; the caller must NOT
+  // pre-load. Returns are camelCase (storageRoot), not the snake_case
+  // form used in .fsmrc.json on disk.
+  const settings = resolveSettings({ fsmName: "code-reviewer" }, repoRoot);
+  return resolve(repoRoot, settings.storageRoot);
 }
 
 const METHODOLOGY_PRINCIPLES = ["SRP", "OCP", "LSP", "ISP", "DIP", "DRY", "KISS", "YAGNI"];

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -147,7 +147,14 @@ export function replayLookup(fixturesRoot, state, hashKey) {
     // Each fixture stores both the original meta (for debugging) and the
     // worker's outputs. The replay path returns just `outputs`; meta is
     // optional and only present when the file was written by recordOutputs.
-    if (parsed && typeof parsed === "object" && parsed.outputs) return parsed.outputs;
+    // Use Object.hasOwn for property presence (not a truthiness check) so
+    // a fixture that legitimately recorded `outputs: null` still returns
+    // null instead of falling back to the wrapping `{outputs, meta}`
+    // object — the call site can distinguish "no fixture" (return null
+    // from existsSync miss) from "fixture exists, output is null".
+    if (parsed && typeof parsed === "object" && Object.hasOwn(parsed, "outputs")) {
+      return parsed.outputs;
+    }
     return parsed;
   } catch {
     return null;

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -212,16 +212,22 @@ export function fixturePath(fixturesRoot, state, hashKey) {
   return join(fixturesRoot, state, `${hashKey}.json`);
 }
 
-// Look up a recorded fixture. Returns the parsed outputs object on hit,
-// null on a true cache miss (fixture file does not exist). Read errors
-// and JSON parse errors throw so the caller can distinguish "no
-// fixture recorded" (the harmless replay miss case) from "fixture
+// Look up a recorded fixture. Returns a structured result so a true
+// cache miss (no file on disk) is unambiguously distinguishable from a
+// legitimate fixture whose recorded `outputs` is null.
+//
+//   { hit: false }              — fixture file does not exist
+//   { hit: true, outputs: ... } — fixture loaded; outputs may be any
+//                                 JSON value, including null
+//
+// Read errors and JSON parse errors throw so the caller can distinguish
+// "no fixture recorded" (the harmless replay miss case) from "fixture
 // recorded but corrupted" (a hard error that masquerading as a miss
 // would silently regress the replay). Replay mode in run-review.mjs
 // turns the throw into a structured fault.
 export function replayLookup(fixturesRoot, state, hashKey) {
   const path = fixturePath(fixturesRoot, state, hashKey);
-  if (!existsSync(path)) return null;
+  if (!existsSync(path)) return { hit: false };
   let raw;
   try {
     raw = readFileSync(path, "utf8");
@@ -241,13 +247,12 @@ export function replayLookup(fixturesRoot, state, hashKey) {
   // Each fixture stores both the original meta (for debugging) and the
   // worker's outputs. The replay path returns just `outputs`; meta is
   // optional and only present when the file was written by recordOutputs.
-  // Use Object.hasOwn for property presence (not a truthiness check) so
-  // a fixture that legitimately recorded `outputs: null` still returns
-  // null instead of falling back to the wrapping `{outputs, meta}` object.
+  // Use Object.hasOwn for property presence so a fixture that legitimately
+  // recorded `outputs: null` is preserved (not collapsed into a miss).
   if (parsed && typeof parsed === "object" && Object.hasOwn(parsed, "outputs")) {
-    return parsed.outputs;
+    return { hit: true, outputs: parsed.outputs };
   }
-  return parsed;
+  return { hit: true, outputs: parsed };
 }
 
 // Persist worker outputs to the fixtures tree. Returns the absolute path

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -130,10 +130,11 @@ export function computeHashKey({ state, promptTemplate, inputs, repoRoot }) {
     if (
       /(^|[\\/])\.\.([\\/]|$)/.test(promptTemplate) ||
       promptTemplate.startsWith("/") ||
+      promptTemplate.startsWith("\\") ||
       /^[A-Za-z]:[\\/]/.test(promptTemplate)
     ) {
       throw new Error(
-        `computeHashKey: promptTemplate must be a repo-relative path with no traversal segments or absolute roots; got ${JSON.stringify(promptTemplate)}`,
+        `computeHashKey: promptTemplate must be a repo-relative path with no traversal segments or absolute / UNC roots; got ${JSON.stringify(promptTemplate)}`,
       );
     }
     const candidate = resolve(repoRoot, promptTemplate);

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -1,0 +1,165 @@
+// worker-replay.mjs — record/replay harness for FSM worker outputs (Sprint B B7).
+//
+// B5's reproducibility test only covers the deterministic inline pipeline.
+// Worker outputs are seeded in the test fixture, so worker-call
+// reproducibility is NOT measured — and real LLM outputs vary run-to-run.
+// This harness fills the gap: every worker invocation can be recorded into
+// a versioned fixture, then replayed deterministically.
+//
+// Three modes (controlled by `--replay-mode` on the runner):
+//
+//   live    — default. Worker runs normally; no record / no replay.
+//   record  — Worker runs normally, but the captured outputs are persisted
+//             to `tests/fixtures/worker-responses/<state-id>/<hash>.json`
+//             when the runner's --continue handler receives them.
+//   replay  — Before pausing on a worker, the runner computes the hash
+//             key from the brief and looks up a recorded fixture. On hit
+//             the runner auto-commits the recorded outputs and continues
+//             the loop without emitting awaiting_worker. On miss it
+//             returns a fault so the missing fixture is loud, not silent.
+//
+// Hash key: sha256 of `<state-id>|<prompt_template>|<canonical-json(inputs)>`.
+// The state id pins which worker; the prompt template path pins the
+// prompt revision (a prompt change ⇒ a new hash); canonical-json(inputs)
+// pins the env payload (a different diff / project profile ⇒ a different
+// hash). Same triple ⇒ same fixture, byte-identical replay.
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const VALID_REPLAY_MODES = new Set(["live", "record", "replay"]);
+
+export function resolveReplayMode(argsBag) {
+  const raw = argsBag?.["replay-mode"];
+  if (typeof raw !== "string") return "live";
+  const norm = raw.trim().toLowerCase();
+  return VALID_REPLAY_MODES.has(norm) ? norm : "live";
+}
+
+// Canonical JSON: stable key ordering at every level so two runs with the
+// same logical inputs produce byte-identical strings (and therefore the
+// same hash). Keys at every object level are sorted lex; arrays preserve
+// order.
+function canonicalize(value) {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  const keys = Object.keys(value).sort();
+  const out = {};
+  for (const k of keys) out[k] = canonicalize(value[k]);
+  return out;
+}
+
+function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+// Hash key for a worker invocation. Inputs:
+//   - state:           FSM state id (e.g. "llm_trim").
+//   - promptTemplate:  the prompt-template path the worker was dispatched
+//                      with, OR (when stable identity matters more than
+//                      content) the SHA of the prompt body itself.
+//   - inputs:          the env payload sent to the worker. Caller projects
+//                      the relevant slice (the FSM brief's `inputs:[...]`
+//                      list) so unrelated env fields don't bust the hash.
+export function computeHashKey({ state, promptTemplate, inputs }) {
+  const h = createHash("sha256");
+  h.update(String(state ?? ""));
+  h.update("\u001f"); // unit-separator — unlikely to appear in any field
+  h.update(String(promptTemplate ?? ""));
+  h.update("\u001f");
+  h.update(canonicalJson(inputs ?? {}));
+  return h.digest("hex");
+}
+
+export function defaultFixturesRoot(metaUrl) {
+  const here = dirname(fileURLToPath(metaUrl));
+  // The harness lives at scripts/lib/; fixtures live at tests/fixtures/.
+  return resolve(here, "..", "..", "tests", "fixtures", "worker-responses");
+}
+
+export function fixturePath(fixturesRoot, state, hashKey) {
+  if (typeof state !== "string" || state.length === 0) {
+    throw new Error("fixturePath: state must be a non-empty string");
+  }
+  if (typeof hashKey !== "string" || !/^[a-f0-9]{64}$/.test(hashKey)) {
+    throw new Error(`fixturePath: hashKey must be 64-char hex sha256; got ${hashKey}`);
+  }
+  return join(fixturesRoot, state, `${hashKey}.json`);
+}
+
+// Look up a recorded fixture. Returns the parsed outputs object on hit,
+// null on miss. Caller decides whether to fault (replay mode) or fall
+// through to live dispatch (live / record).
+export function replayLookup(fixturesRoot, state, hashKey) {
+  const path = fixturePath(fixturesRoot, state, hashKey);
+  if (!existsSync(path)) return null;
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    // Each fixture stores both the original meta (for debugging) and the
+    // worker's outputs. The replay path returns just `outputs`; meta is
+    // optional and only present when the file was written by recordOutputs.
+    if (parsed && typeof parsed === "object" && parsed.outputs) return parsed.outputs;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+// Persist worker outputs to the fixtures tree. Returns the absolute path
+// the fixture was written to so the caller can log / surface it.
+export function recordOutputs(
+  fixturesRoot,
+  { state, hashKey, outputs, meta = null },
+) {
+  const path = fixturePath(fixturesRoot, state, hashKey);
+  mkdirSync(dirname(path), { recursive: true });
+  const payload = meta === null ? { outputs } : { meta, outputs };
+  writeFileSync(path, JSON.stringify(payload, null, 2) + "\n");
+  return path;
+}
+
+// In record mode the runner needs to remember which worker brief produced
+// the outputs that arrive in --continue. Stash a minimal record under the
+// run directory; --continue reads it back, computes the fixture path,
+// writes the fixture, and removes the stash. The stash file lives next to
+// the run's manifest.json so it inherits the same lifecycle.
+const STASH_FILENAME = ".replay-pending.json";
+
+export function stashPendingBrief(runDir, { state, hashKey }) {
+  const path = join(runDir, STASH_FILENAME);
+  writeFileSync(path, JSON.stringify({ state, hashKey }) + "\n");
+  return path;
+}
+
+export function readPendingBrief(runDir) {
+  const path = join(runDir, STASH_FILENAME);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingBrief(runDir) {
+  const path = join(runDir, STASH_FILENAME);
+  if (!existsSync(path)) return;
+  try {
+    writeFileSync(path, "");
+  } catch {
+    // best-effort — the stash is internal bookkeeping, not user-visible.
+  }
+}

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -44,11 +44,35 @@ export const FIXTURES_ROOT = resolve(__replay_dirname, "..", "..", "tests", "fix
 
 export const VALID_REPLAY_MODES = new Set(["live", "record", "replay"]);
 
-export function resolveReplayMode(argsBag) {
-  const raw = argsBag?.["replay-mode"];
-  if (typeof raw !== "string") return "live";
+// Resolve --replay-mode. Default (flag absent) is "live". A bare flag
+// (parseArgs sets `args["replay-mode"] = true`) or a non-string value
+// is treated as a misuse and surfaced via `onInvalid` so the runner can
+// fail fast — silently falling back to "live" would let a user run in
+// what they believe is record mode while nothing lands on disk.
+//
+// Unknown but non-empty string values are also treated as invalid for
+// the same reason. The set of accepted values is fixed; a typo (e.g.
+// `--replay-mode=recordd`) should fail loud.
+export function resolveReplayMode(argsBag, { onInvalid } = {}) {
+  if (argsBag === null || argsBag === undefined) return "live";
+  const raw = argsBag["replay-mode"];
+  if (raw === undefined) return "live";
+  if (typeof raw !== "string") {
+    if (typeof onInvalid === "function") {
+      onInvalid(
+        `--replay-mode requires a value: one of ${[...VALID_REPLAY_MODES].join(", ")} (got bare flag)`,
+      );
+    }
+    return "live";
+  }
   const norm = raw.trim().toLowerCase();
-  return VALID_REPLAY_MODES.has(norm) ? norm : "live";
+  if (VALID_REPLAY_MODES.has(norm)) return norm;
+  if (typeof onInvalid === "function") {
+    onInvalid(
+      `--replay-mode must be one of ${[...VALID_REPLAY_MODES].join(", ")} (got: ${JSON.stringify(raw)})`,
+    );
+  }
+  return "live";
 }
 
 // Canonical JSON: stable key ordering at every level so two runs with the
@@ -163,6 +187,12 @@ export function replayLookup(fixturesRoot, state, hashKey) {
 
 // Persist worker outputs to the fixtures tree. Returns the absolute path
 // the fixture was written to so the caller can log / surface it.
+//
+// The payload is canonicalized (keys sorted at every object level) before
+// stringification so re-recording semantically identical outputs produces
+// byte-identical files regardless of which order the worker emitted keys.
+// Without this, two correct runs against the same brief would generate
+// noisy diffs when refreshing fixtures.
 export function recordOutputs(
   fixturesRoot,
   { state, hashKey, outputs, meta = null },
@@ -170,7 +200,7 @@ export function recordOutputs(
   const path = fixturePath(fixturesRoot, state, hashKey);
   mkdirSync(dirname(path), { recursive: true });
   const payload = meta === null ? { outputs } : { meta, outputs };
-  writeFileSync(path, JSON.stringify(payload, null, 2) + "\n");
+  writeFileSync(path, JSON.stringify(canonicalize(payload), null, 2) + "\n");
   return path;
 }
 

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -31,8 +31,16 @@ import {
   writeFileSync,
 } from "node:fs";
 import { createHash } from "node:crypto";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+// Compute the fixtures root from THIS module's location (scripts/lib/),
+// not from a caller-supplied metaUrl. The previous shape was misuse-prone:
+// a caller in scripts/run-review.mjs passing import.meta.url would resolve
+// `.., ..` to the parent of the repo. Pin the derivation to this file so
+// any caller gets the right path.
+const __replay_dirname = dirname(fileURLToPath(import.meta.url));
+export const FIXTURES_ROOT = resolve(__replay_dirname, "..", "..", "tests", "fixtures", "worker-responses");
 
 export const VALID_REPLAY_MODES = new Set(["live", "record", "replay"]);
 
@@ -62,32 +70,60 @@ function canonicalJson(value) {
 
 // Hash key for a worker invocation. Inputs:
 //   - state:           FSM state id (e.g. "llm_trim").
-//   - promptTemplate:  the prompt-template path the worker was dispatched
-//                      with, OR (when stable identity matters more than
-//                      content) the SHA of the prompt body itself.
+//   - promptTemplate:  the prompt-template PATH (relative to repo root).
+//                      Used both as a stable identity AND to read the
+//                      prompt body so the hash buckets on prompt CONTENT,
+//                      not just the path. Editing the prompt without
+//                      renaming the file ⇒ different hash ⇒ replay miss
+//                      ⇒ caller knows the fixture is stale.
 //   - inputs:          the env payload sent to the worker. Caller projects
 //                      the relevant slice (the FSM brief's `inputs:[...]`
 //                      list) so unrelated env fields don't bust the hash.
-export function computeHashKey({ state, promptTemplate, inputs }) {
+//   - repoRoot:        optional; only used to read the prompt body. When
+//                      omitted, only the path is hashed (back-compat with
+//                      callers that don't have repo-root context).
+export function computeHashKey({ state, promptTemplate, inputs, repoRoot }) {
   const h = createHash("sha256");
   h.update(String(state ?? ""));
   h.update("\u001f"); // unit-separator — unlikely to appear in any field
   h.update(String(promptTemplate ?? ""));
   h.update("\u001f");
+  // Hash the prompt body when we can read it, so a content edit invalidates
+  // every recorded fixture for that worker. Missing / unreadable file is
+  // captured as the empty-content marker so the hash is still defined.
+  let promptBody = "";
+  if (typeof repoRoot === "string" && typeof promptTemplate === "string" && promptTemplate.length > 0) {
+    const candidate = resolve(repoRoot, promptTemplate);
+    try {
+      promptBody = readFileSync(candidate, "utf8");
+    } catch {
+      // Treat unreadable prompts as empty; the hash still differs from
+      // any fixture recorded against a real prompt.
+    }
+  }
+  h.update(promptBody);
+  h.update("\u001f");
   h.update(canonicalJson(inputs ?? {}));
   return h.digest("hex");
 }
 
-export function defaultFixturesRoot(metaUrl) {
-  const here = dirname(fileURLToPath(metaUrl));
-  // The harness lives at scripts/lib/; fixtures live at tests/fixtures/.
-  return resolve(here, "..", "..", "tests", "fixtures", "worker-responses");
-}
-
-export function fixturePath(fixturesRoot, state, hashKey) {
+// Reject path-traversal in `state` so a tampered `.replay-pending.json`
+// (or any other untrusted source for `state`) can't direct
+// `recordOutputs` to write outside the fixtures tree via `join`.
+function assertSafeStateSegment(state) {
   if (typeof state !== "string" || state.length === 0) {
     throw new Error("fixturePath: state must be a non-empty string");
   }
+  if (state.includes("/") || state.includes("\\") || state.includes("..")) {
+    throw new Error(`fixturePath: state must not contain path separators or '..' (got: ${state})`);
+  }
+  if (isAbsolute(state)) {
+    throw new Error(`fixturePath: state must not be an absolute path (got: ${state})`);
+  }
+}
+
+export function fixturePath(fixturesRoot, state, hashKey) {
+  assertSafeStateSegment(state);
   if (typeof hashKey !== "string" || !/^[a-f0-9]{64}$/.test(hashKey)) {
     throw new Error(`fixturePath: hashKey must be 64-char hex sha256; got ${hashKey}`);
   }

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -122,6 +122,20 @@ export function computeHashKey({ state, promptTemplate, inputs, repoRoot }) {
   // hashing only the path — that mode is documented and intentional.
   let promptBody = "";
   if (typeof repoRoot === "string" && typeof promptTemplate === "string" && promptTemplate.length > 0) {
+    // Defense in depth: even though the runner runs paths through
+    // repoRelativePromptPath first, computeHashKey is exported and
+    // could be called from tooling that forgets the upstream sanitiser.
+    // Reject traversal / absolute paths here too so a misuse can't
+    // pull `<repoRoot>/../etc/passwd` into the hash.
+    if (
+      /(^|[\\/])\.\.([\\/]|$)/.test(promptTemplate) ||
+      promptTemplate.startsWith("/") ||
+      /^[A-Za-z]:[\\/]/.test(promptTemplate)
+    ) {
+      throw new Error(
+        `computeHashKey: promptTemplate must be a repo-relative path with no traversal segments or absolute roots; got ${JSON.stringify(promptTemplate)}`,
+      );
+    }
     const candidate = resolve(repoRoot, promptTemplate);
     try {
       promptBody = readFileSync(candidate, "utf8");

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -113,16 +113,23 @@ export function computeHashKey({ state, promptTemplate, inputs, repoRoot }) {
   h.update(String(promptTemplate ?? ""));
   h.update("\u001f");
   // Hash the prompt body when we can read it, so a content edit invalidates
-  // every recorded fixture for that worker. Missing / unreadable file is
-  // captured as the empty-content marker so the hash is still defined.
+  // every recorded fixture for that worker. A missing / unreadable file
+  // when a `repoRoot` AND `promptTemplate` were both provided is treated
+  // as a hard error: it's almost always a misconfigured promptTemplate
+  // path, and silently mapping it to "" would mask a bug as a systematic
+  // replay miss that's hard to root-cause. When `repoRoot` is omitted
+  // (back-compat for callers without repo-root context), we fall back to
+  // hashing only the path — that mode is documented and intentional.
   let promptBody = "";
   if (typeof repoRoot === "string" && typeof promptTemplate === "string" && promptTemplate.length > 0) {
     const candidate = resolve(repoRoot, promptTemplate);
     try {
       promptBody = readFileSync(candidate, "utf8");
-    } catch {
-      // Treat unreadable prompts as empty; the hash still differs from
-      // any fixture recorded against a real prompt.
+    } catch (err) {
+      throw new Error(
+        `computeHashKey: prompt template not readable at ${candidate} (${err.code ?? err.message}). ` +
+          `Check that promptTemplate is correct relative to repoRoot. To opt out of content hashing, omit repoRoot.`,
+      );
     }
   }
   h.update(promptBody);

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -131,6 +131,12 @@ export function computeHashKey({ state, promptTemplate, inputs, repoRoot }) {
           `Check that promptTemplate is correct relative to repoRoot. To opt out of content hashing, omit repoRoot.`,
       );
     }
+    // Normalize line endings so the same logical prompt produces the
+    // same hash on Windows (CRLF after a checkout with core.autocrlf=true)
+    // and on Linux (LF). Without this, every fixture recorded on Linux
+    // would replay-miss on Windows and vice versa, even though the
+    // semantic content is identical.
+    promptBody = promptBody.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   }
   h.update(promptBody);
   h.update("\u001f");

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -28,10 +28,11 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   writeFileSync,
 } from "node:fs";
 import { createHash } from "node:crypto";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // Compute the fixtures root from THIS module's location (scripts/lib/),
@@ -138,12 +139,41 @@ export function computeHashKey({ state, promptTemplate, inputs, repoRoot }) {
       );
     }
     const candidate = resolve(repoRoot, promptTemplate);
+    // Symlink-safe boundary check: even with traversal/absolute strings
+    // rejected up-front, a `promptTemplate` like `fsm/workers/p.md`
+    // could target a symlink inside the repo whose realpath escapes
+    // outside it. Resolve both the candidate AND the repoRoot, then
+    // assert the realpath candidate is INSIDE the realpath repoRoot.
+    let realRoot;
     try {
-      promptBody = readFileSync(candidate, "utf8");
+      realRoot = realpathSync(repoRoot);
+    } catch {
+      // If repoRoot itself isn't realpath-able, treat as fatal — the
+      // hash bucket can't be defined.
+      throw new Error(
+        `computeHashKey: repoRoot not realpath-able: ${repoRoot}`,
+      );
+    }
+    let realCandidate;
+    try {
+      realCandidate = realpathSync(candidate);
     } catch (err) {
       throw new Error(
         `computeHashKey: prompt template not readable at ${candidate} (${err.code ?? err.message}). ` +
           `Check that promptTemplate is correct relative to repoRoot. To opt out of content hashing, omit repoRoot.`,
+      );
+    }
+    const rel = relative(realRoot, realCandidate);
+    if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+      throw new Error(
+        `computeHashKey: promptTemplate symlink escapes repoRoot (resolved to ${realCandidate}); rejecting.`,
+      );
+    }
+    try {
+      promptBody = readFileSync(realCandidate, "utf8");
+    } catch (err) {
+      throw new Error(
+        `computeHashKey: prompt template not readable at ${realCandidate} (${err.code ?? err.message}).`,
       );
     }
     // Normalize line endings so the same logical prompt produces the

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -162,34 +162,41 @@ export function fixturePath(fixturesRoot, state, hashKey) {
 }
 
 // Look up a recorded fixture. Returns the parsed outputs object on hit,
-// null on miss. Caller decides whether to fault (replay mode) or fall
-// through to live dispatch (live / record).
+// null on a true cache miss (fixture file does not exist). Read errors
+// and JSON parse errors throw so the caller can distinguish "no
+// fixture recorded" (the harmless replay miss case) from "fixture
+// recorded but corrupted" (a hard error that masquerading as a miss
+// would silently regress the replay). Replay mode in run-review.mjs
+// turns the throw into a structured fault.
 export function replayLookup(fixturesRoot, state, hashKey) {
   const path = fixturePath(fixturesRoot, state, hashKey);
   if (!existsSync(path)) return null;
   let raw;
   try {
     raw = readFileSync(path, "utf8");
-  } catch {
-    return null;
+  } catch (err) {
+    throw new Error(
+      `replayLookup: fixture exists at ${path} but is unreadable (${err.code ?? err.message}). Delete or fix the fixture, then re-record.`,
+    );
   }
+  let parsed;
   try {
-    const parsed = JSON.parse(raw);
-    // Each fixture stores both the original meta (for debugging) and the
-    // worker's outputs. The replay path returns just `outputs`; meta is
-    // optional and only present when the file was written by recordOutputs.
-    // Use Object.hasOwn for property presence (not a truthiness check) so
-    // a fixture that legitimately recorded `outputs: null` still returns
-    // null instead of falling back to the wrapping `{outputs, meta}`
-    // object — the call site can distinguish "no fixture" (return null
-    // from existsSync miss) from "fixture exists, output is null".
-    if (parsed && typeof parsed === "object" && Object.hasOwn(parsed, "outputs")) {
-      return parsed.outputs;
-    }
-    return parsed;
-  } catch {
-    return null;
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `replayLookup: fixture at ${path} is invalid JSON (${err.message}). Delete or fix the fixture, then re-record.`,
+    );
   }
+  // Each fixture stores both the original meta (for debugging) and the
+  // worker's outputs. The replay path returns just `outputs`; meta is
+  // optional and only present when the file was written by recordOutputs.
+  // Use Object.hasOwn for property presence (not a truthiness check) so
+  // a fixture that legitimately recorded `outputs: null` still returns
+  // null instead of falling back to the wrapping `{outputs, meta}` object.
+  if (parsed && typeof parsed === "object" && Object.hasOwn(parsed, "outputs")) {
+    return parsed.outputs;
+  }
+  return parsed;
 }
 
 // Persist worker outputs to the fixtures tree. Returns the absolute path

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -570,11 +570,17 @@ async function main() {
         );
       }
       try {
+        // Don't write a wall-clock timestamp into the fixture meta — the
+        // whole point of canonicalized record mode is byte-stable
+        // refresh, and a per-record `recorded_at` would force a diff
+        // every time a maintainer re-records the same logical brief.
+        // The run id is similarly per-invocation noise. recordOutputs
+        // skips the meta wrapper entirely when meta is null, so the
+        // fixture body collapses to `{ outputs: <outputs> }`.
         recordOutputs(FIXTURES_ROOT, {
           state: stash.state,
           hashKey: stash.hashKey,
           outputs,
-          meta: { recorded_at: new Date().toISOString(), run_id: runId },
         });
         clearPendingBrief(dir);
       } catch (err) {

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -44,10 +44,8 @@ import {
   stashPendingBrief,
   readPendingBrief,
   clearPendingBrief,
-  defaultFixturesRoot,
+  FIXTURES_ROOT,
 } from "./lib/worker-replay.mjs";
-
-const FIXTURES_ROOT = defaultFixturesRoot(import.meta.url);
 
 // Project the FSM brief's declared inputs out of the run env so the hash
 // key only depends on what the worker actually sees, not the full env.
@@ -63,6 +61,10 @@ function hashKeyForBrief(brief, env) {
     state: brief?.state,
     promptTemplate: brief?.prompt_template ?? brief?.worker?.prompt_template ?? "",
     inputs: projectBriefInputs(brief, env),
+    // Pass repoRoot so the harness reads the prompt body and includes its
+    // SHA in the hash — editing the prose without renaming the file
+    // invalidates every recorded fixture for that worker.
+    repoRoot: REPO_ROOT,
   });
 }
 

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -498,7 +498,12 @@ async function main() {
     // Read replay-mode from the runner-level CLI flag only. Pulling it
      // from argsBag would forward it into env.args (the FSM run env),
      // which makes the worker hash differ between record vs replay.
-    const replayMode = resolveReplayMode({ "replay-mode": args["replay-mode"] });
+    const replayMode = resolveReplayMode(
+      { "replay-mode": args["replay-mode"] },
+      {
+        onInvalid: (msg) => fail(msg, { flag: "--replay-mode" }),
+      },
+    );
     emit(await loop(brief, brief.run_id, { replayMode }));
     return;
   }
@@ -531,7 +536,12 @@ async function main() {
     // record/replay flow should set the same mode on every call. (A
     // future enhancement could persist the mode in the run dir's
     // manifest, but for now per-call is the documented contract.)
-    const replayMode = resolveReplayMode({ "replay-mode": args["replay-mode"] });
+    const replayMode = resolveReplayMode(
+      { "replay-mode": args["replay-mode"] },
+      {
+        onInvalid: (msg) => fail(msg, { flag: "--replay-mode" }),
+      },
+    );
 
     const commit = runFsmCommit({ runId, outputs });
     if (!commit.ok) {

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -34,7 +34,37 @@ import { dirname, join, resolve } from "node:path";
 import { tmpdir, platform } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { loadConfig, resolveSettings, runEnv } from "@ctxr/fsm";
+import { loadConfig, resolveSettings, runEnv, runDirPath } from "@ctxr/fsm";
+
+import {
+  resolveReplayMode,
+  computeHashKey,
+  replayLookup,
+  recordOutputs,
+  stashPendingBrief,
+  readPendingBrief,
+  clearPendingBrief,
+  defaultFixturesRoot,
+} from "./lib/worker-replay.mjs";
+
+const FIXTURES_ROOT = defaultFixturesRoot(import.meta.url);
+
+// Project the FSM brief's declared inputs out of the run env so the hash
+// key only depends on what the worker actually sees, not the full env.
+function projectBriefInputs(brief, env) {
+  const names = Array.isArray(brief?.inputs) ? brief.inputs : [];
+  const out = {};
+  for (const name of names) out[name] = env?.[name];
+  return out;
+}
+
+function hashKeyForBrief(brief, env) {
+  return computeHashKey({
+    state: brief?.state,
+    promptTemplate: brief?.prompt_template ?? brief?.worker?.prompt_template ?? "",
+    inputs: projectBriefInputs(brief, env),
+  });
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
@@ -91,6 +121,7 @@ const ALLOWED_ARGS_KEYS = new Set([
   "mode",
   "description",
   "max-reviewers",
+  "replay-mode",
 ]);
 function validateArgsBag(bag) {
   if (bag === null || typeof bag !== "object" || Array.isArray(bag)) {
@@ -330,7 +361,7 @@ async function dispatchInlineState(brief, runId) {
 
 // Drive the loop from a starting brief: walk inline states, pause on workers,
 // stop on terminal. Returns the final status payload to emit.
-async function loop(brief, runId) {
+async function loop(brief, runId, { replayMode = "live" } = {}) {
   let current = brief;
   while (true) {
     if (current.status === "terminal") {
@@ -342,13 +373,51 @@ async function loop(brief, runId) {
       };
     }
     if (current.has_worker) {
-      // The runner does not pre-compute activation-gate signals into the env
-      // here — the tree-descender worker prose instructs the LLM to invoke
-      // `scripts/lib/activation-gate.mjs` itself today. Lifting that
-      // pre-compute up to the runner (so any worker can consume
-      // activated_leaves[] from env without an LLM hop) is part of the B6
-      // reframe (#11). For now this branch is intentionally a thin
-      // pass-through.
+      const storageRoot = resolveStorageRoot();
+      const env = runEnv(runId, { storageRoot });
+      const hashKey = hashKeyForBrief(current, env);
+
+      // B7 replay mode: try to satisfy the worker call from a recorded
+      // fixture. On hit, auto-commit the recorded outputs and continue
+      // the loop without ever emitting awaiting_worker. On miss, return
+      // a fault — silent fall-through to live dispatch would defeat the
+      // determinism the harness exists to provide.
+      if (replayMode === "replay") {
+        const cached = replayLookup(FIXTURES_ROOT, current.state, hashKey);
+        if (cached === null) {
+          return {
+            status: "fault",
+            run_id: runId,
+            fault: {
+              state: current.state,
+              reason: `replay-mode miss: no fixture for state="${current.state}" hashKey=${hashKey.slice(0, 12)}...`,
+              hash_key: hashKey,
+            },
+          };
+        }
+        const commit = runFsmCommit({ runId, outputs: cached });
+        if (!commit.ok) {
+          return {
+            status: "fault",
+            run_id: runId,
+            fault: { state: current.state, reason: commit.error, details: commit.raw },
+          };
+        }
+        current = commit.payload;
+        continue;
+      }
+
+      // B7 record mode: stash the brief so --continue knows where to file
+      // the captured outputs. Live mode also stashes (cheap, harmless) so
+      // a subsequent --replay-mode=record on --continue still works
+      // without requiring the original --start to have set the flag.
+      const dir = runDirPath(runId, { storageRoot });
+      try {
+        stashPendingBrief(dir, { state: current.state, hashKey });
+      } catch {
+        // Stash is best-effort bookkeeping; never fail the run on it.
+      }
+
       return { status: "awaiting_worker", run_id: runId, brief: current };
     }
     const dispatch = await dispatchInlineState(current, runId);
@@ -419,7 +488,8 @@ async function main() {
       fail(`fsm-next --new-run failed: ${start.error}`, { raw: start.raw });
     }
     const brief = start.payload;
-    emit(await loop(brief, brief.run_id));
+    const replayMode = resolveReplayMode({ "replay-mode": args["replay-mode"] ?? argsBag["replay-mode"] });
+    emit(await loop(brief, brief.run_id, { replayMode }));
     return;
   }
 
@@ -443,11 +513,36 @@ async function main() {
       fail(`--run-id must be lowercase alnum + dashes, 3-64 chars; got: ${runId}`);
     }
     const outputs = readJsonFile(outputsFile, "--outputs-file");
+    const replayMode = resolveReplayMode({ "replay-mode": args["replay-mode"] });
+
+    // B7 record mode: persist the worker outputs we just received under
+    // the hash key the runner stashed when it emitted awaiting_worker.
+    // Done BEFORE fsm-commit so a commit failure doesn't leave a
+    // half-recorded fixture without its corresponding env update.
+    if (replayMode === "record") {
+      try {
+        const storageRoot = resolveStorageRoot();
+        const dir = runDirPath(runId, { storageRoot });
+        const stash = readPendingBrief(dir);
+        if (stash && typeof stash.state === "string" && typeof stash.hashKey === "string") {
+          recordOutputs(FIXTURES_ROOT, {
+            state: stash.state,
+            hashKey: stash.hashKey,
+            outputs,
+            meta: { recorded_at: new Date().toISOString(), run_id: runId },
+          });
+          clearPendingBrief(dir);
+        }
+      } catch {
+        // Recording is opt-in instrumentation; never fail the run on it.
+      }
+    }
+
     const commit = runFsmCommit({ runId, outputs });
     if (!commit.ok) {
       fail(`fsm-commit failed: ${commit.error}`, { raw: commit.raw });
     }
-    emit(await loop(commit.payload, runId));
+    emit(await loop(commit.payload, runId, { replayMode }));
     return;
   }
 

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -34,7 +34,7 @@ import { dirname, join, resolve } from "node:path";
 import { tmpdir, platform } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { loadConfig, resolveSettings, runEnv, runDirPath } from "@ctxr/fsm";
+import { resolveSettings, runEnv, runDirPath } from "@ctxr/fsm";
 
 import {
   resolveReplayMode,
@@ -70,6 +70,23 @@ const FSM_YAML_DIR_REL = "fsm";
 
 export function repoRelativePromptPath(briefPath) {
   if (typeof briefPath !== "string" || briefPath.length === 0) return "";
+  // Reject absolute paths and any traversal segment up front. The hashing
+  // harness reads `<repoRoot>/<promptTemplate>`; without these guards a
+  // brief carrying `../etc/passwd` or `/abs/path` would let a tampered
+  // FSM YAML pull arbitrary files into the hash (and into the recorded
+  // fixture's content fingerprint). Legitimate shapes are
+  // `workers/<role>.md` (FSM-yaml-relative) or `fsm/workers/<role>.md`
+  // (already repo-relative). Throw rather than silently sanitize so a
+  // malformed brief surfaces immediately.
+  if (
+    /(^|[\\/])\.\.([\\/]|$)/.test(briefPath) ||
+    briefPath.startsWith("/") ||
+    /^[A-Za-z]:[\\/]/.test(briefPath)
+  ) {
+    throw new Error(
+      `repoRelativePromptPath: traversal / absolute paths are rejected; got ${JSON.stringify(briefPath)}`,
+    );
+  }
   // Already repo-relative (starts with `fsm/`) → pass through unchanged.
   // Otherwise prepend the FSM-YAML directory so paths like
   // `workers/project-scanner.md` become `fsm/workers/project-scanner.md`.
@@ -101,9 +118,15 @@ const REPO_ROOT = resolve(__dirname, "..");
 const INLINE_STATES_DIR = resolve(__dirname, "inline-states");
 
 function resolveStorageRoot() {
-  const config = loadConfig(REPO_ROOT);
-  const settings = resolveSettings(config, { fsmName: "code-reviewer" });
-  return resolve(REPO_ROOT, settings.storage_root);
+  // @ctxr/fsm exposes resolveSettings(cliArgs, cwd) — cliArgs is the
+  // selector ({fsmName, fsmPath, storageRoot, sessionId}), cwd is the
+  // directory to resolve the .fsmrc.json relative to. resolveSettings
+  // calls loadConfig internally; the caller does NOT pre-load. Earlier
+  // rounds of this file had it backwards (loadConfig({cwd: REPO_ROOT})
+  // and resolveSettings(config, {...})), which was hidden because this
+  // function is only on the --continue path.
+  const settings = resolveSettings({ fsmName: "code-reviewer" }, REPO_ROOT);
+  return resolve(REPO_ROOT, settings.storageRoot);
 }
 
 export function parseArgs(argv) {

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -853,6 +853,21 @@ async function main() {
           { state: stash.state, hash_key: stash.hashKey },
         );
       }
+    } else {
+      // Live / replay --continue: even when we're not recording the
+      // current step, clear any previous-step stash if it's there.
+      // Otherwise a stash left over from a record-mode --start could
+      // be picked up by a later record-mode --continue against the
+      // wrong outputs (the stash is keyed only on `{state, hashKey}`,
+      // not on the specific output payload). Best-effort: a missing
+      // run dir or unreadable stash is the harmless case.
+      try {
+        const storageRoot = resolveStorageRoot();
+        const dir = runDirPath(runId, { storageRoot });
+        clearPendingBrief(dir);
+      } catch {
+        // ignore — clearing is best-effort housekeeping, not load-bearing
+      }
     }
 
     emit(await loop(commit.payload, runId, { replayMode }));

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -49,10 +49,19 @@ import {
 
 // Project the FSM brief's declared inputs out of the run env so the hash
 // key only depends on what the worker actually sees, not the full env.
+// fsm-next can expose the inputs list either at the top level
+// (`brief.inputs`) or nested under the worker block (`brief.worker.inputs`),
+// matching how prompt_template is exposed. Fall back so a hash isn't
+// computed against an empty inputs list when the brief uses the nested
+// shape.
 function projectBriefInputs(brief, env) {
-  const names = Array.isArray(brief?.inputs) ? brief.inputs : [];
+  const namesRaw = Array.isArray(brief?.inputs)
+    ? brief.inputs
+    : Array.isArray(brief?.worker?.inputs)
+      ? brief.worker.inputs
+      : [];
   const out = {};
-  for (const name of names) out[name] = env?.[name];
+  for (const name of namesRaw) out[name] = env?.[name];
   return out;
 }
 
@@ -548,8 +557,12 @@ export function handleWorkerStateBrief(brief, runId, opts = {}, _deps = {}) {
   // surface as faults — without the stash, --continue can't persist
   // the recorded fixture and the user would think record-mode
   // succeeded when it silently didn't. (Live mode returned early.)
-  const dir = runDirPathFn(runId, { storageRoot });
+  // Wrap both runDirPath AND stashPendingBrief in the same try/catch:
+  // runDirPath can throw on a missing/corrupt run-storage tree, and
+  // an unhandled throw there would crash the runner instead of
+  // surfacing as the same structured fault that a stash failure does.
   try {
+    const dir = runDirPathFn(runId, { storageRoot });
     stashPendingBriefFn(dir, { state: brief.state, hashKey });
   } catch (err) {
     return {

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -442,8 +442,27 @@ export function handleWorkerStateBrief(brief, runId, opts = {}, _deps = {}) {
   const runDirPathFn = _deps.runDirPath ?? runDirPath;
   const fixturesRoot = _deps.fixturesRoot ?? FIXTURES_ROOT;
 
-  const storageRoot = resolveStorageRootFn();
-  const env = runEnvFn(runId, { storageRoot });
+  // resolveStorageRoot reads .fsmrc.json + walks @ctxr/fsm config; runEnv
+  // reads the run-storage tree on disk. Either can throw on a missing /
+  // corrupt config or storage. Convert to an in-flow fault so the run
+  // stops cleanly instead of crashing out as a top-level {status:"error"}.
+  let storageRoot, env;
+  try {
+    storageRoot = resolveStorageRootFn();
+    env = runEnvFn(runId, { storageRoot });
+  } catch (err) {
+    return {
+      kind: "fault",
+      payload: {
+        status: "fault",
+        run_id: runId,
+        fault: {
+          state: brief.state,
+          reason: `failed to load run env: ${err?.message ?? String(err)}`,
+        },
+      },
+    };
+  }
 
   // hashKeyForBrief can throw when the prompt template is unreadable.
   let hashKey;
@@ -482,7 +501,7 @@ export function handleWorkerStateBrief(brief, runId, opts = {}, _deps = {}) {
         },
       };
     }
-    if (cached === null) {
+    if (!cached.hit) {
       return {
         kind: "fault",
         payload: {
@@ -496,7 +515,7 @@ export function handleWorkerStateBrief(brief, runId, opts = {}, _deps = {}) {
         },
       };
     }
-    const commit = runFsmCommitFn({ runId, outputs: cached });
+    const commit = runFsmCommitFn({ runId, outputs: cached.outputs });
     if (!commit.ok) {
       return {
         kind: "fault",

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -56,10 +56,38 @@ function projectBriefInputs(brief, env) {
   return out;
 }
 
+// In the FSM YAML, prompt_template paths are written relative to the FSM
+// YAML's own directory (e.g. `workers/project-scanner.md`), not relative
+// to the repo root. computeHashKey expects a path relative to repoRoot
+// when reading the prompt body, so the runner projects the brief's path
+// into a repo-relative one before calling it.
+//
+// The FSM YAML for this project lives at `fsm/code-reviewer.fsm.yaml`
+// (configured in .fsmrc.json). Hardcoding the prefix here is simpler
+// than going through loadConfig/resolveSettings every call AND keeps
+// this helper purely synchronous + testable without a config gate.
+const FSM_YAML_DIR_REL = "fsm";
+
+export function repoRelativePromptPath(briefPath) {
+  if (typeof briefPath !== "string" || briefPath.length === 0) return "";
+  // Already repo-relative (starts with `fsm/`) → pass through unchanged.
+  // Otherwise prepend the FSM-YAML directory so paths like
+  // `workers/project-scanner.md` become `fsm/workers/project-scanner.md`.
+  const norm = briefPath.split(/[/\\]+/).join("/");
+  if (norm.startsWith(`${FSM_YAML_DIR_REL}/`) || norm === FSM_YAML_DIR_REL) {
+    return norm;
+  }
+  return `${FSM_YAML_DIR_REL}/${norm}`;
+}
+
 function hashKeyForBrief(brief, env) {
+  const briefPath = brief?.prompt_template ?? brief?.worker?.prompt_template ?? "";
   return computeHashKey({
     state: brief?.state,
-    promptTemplate: brief?.prompt_template ?? brief?.worker?.prompt_template ?? "",
+    // Project the FSM-yaml-relative path to a repo-relative one so
+    // computeHashKey's `resolve(repoRoot, promptTemplate)` finds the
+    // actual prompt file under fsm/workers/.
+    promptTemplate: repoRelativePromptPath(briefPath),
     inputs: projectBriefInputs(brief, env),
     // Pass repoRoot so the harness reads the prompt body and includes its
     // SHA in the hash — editing the prose without renaming the file
@@ -73,7 +101,7 @@ const REPO_ROOT = resolve(__dirname, "..");
 const INLINE_STATES_DIR = resolve(__dirname, "inline-states");
 
 function resolveStorageRoot() {
-  const config = loadConfig({ cwd: REPO_ROOT });
+  const config = loadConfig(REPO_ROOT);
   const settings = resolveSettings(config, { fsmName: "code-reviewer" });
   return resolve(REPO_ROOT, settings.storage_root);
 }

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -200,6 +200,14 @@ export function parseArgs(argv) {
     // positionals.
     if (a === "--") break;
     if (!a.startsWith("--")) continue;
+    // Support both `--key value` and `--key=value` forms. The latter is
+    // what most CLIs accept by convention, and our docs show that shape.
+    const eq = a.indexOf("=");
+    if (eq !== -1) {
+      const key = a.slice(2, eq);
+      args[key] = a.slice(eq + 1);
+      continue;
+    }
     const key = a.slice(2);
     const next = argv[i + 1];
     if (next === undefined || next === "--" || next.startsWith("--")) {

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -779,7 +779,7 @@ async function main() {
         clearPendingBrief(dir);
       } catch (err) {
         fail(
-          `replay-mode=record: failed to persist fixture for state=${stash.state}: ${err.message}`,
+          `replay-mode=record: failed to persist fixture for state=${stash.state}: ${err?.message ?? String(err)}`,
           { state: stash.state, hash_key: stash.hashKey },
         );
       }

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -123,7 +123,12 @@ const ALLOWED_ARGS_KEYS = new Set([
   "mode",
   "description",
   "max-reviewers",
-  "replay-mode",
+  // `replay-mode` is intentionally NOT in this set — it's a runner-level
+  // CLI flag, not part of the FSM run's `args` env (per report-format.md).
+  // Forwarding it into env.args would mean the same worker invocation
+  // hashes differently depending on whether the user passed
+  // --replay-mode=live vs left the flag off, defeating the determinism
+  // the harness exists to provide.
 ]);
 function validateArgsBag(bag) {
   if (bag === null || typeof bag !== "object" || Array.isArray(bag)) {
@@ -490,7 +495,10 @@ async function main() {
       fail(`fsm-next --new-run failed: ${start.error}`, { raw: start.raw });
     }
     const brief = start.payload;
-    const replayMode = resolveReplayMode({ "replay-mode": args["replay-mode"] ?? argsBag["replay-mode"] });
+    // Read replay-mode from the runner-level CLI flag only. Pulling it
+     // from argsBag would forward it into env.args (the FSM run env),
+     // which makes the worker hash differ between record vs replay.
+    const replayMode = resolveReplayMode({ "replay-mode": args["replay-mode"] });
     emit(await loop(brief, brief.run_id, { replayMode }));
     return;
   }
@@ -515,18 +523,38 @@ async function main() {
       fail(`--run-id must be lowercase alnum + dashes, 3-64 chars; got: ${runId}`);
     }
     const outputs = readJsonFile(outputsFile, "--outputs-file");
+
+    // B8 referential-integrity check (extracted into runTrimValidationGate
+    // so unit tests can exercise it without a live runner).
+    runTrimValidationGate(runId, outputs);
+
+    // --replay-mode must be passed on EACH --continue invocation. The
+    // runner is stateless across CLI calls; if --start was invoked with
+    // --replay-mode=record but a subsequent --continue omitted the flag,
+    // those outputs would silently NOT be recorded. Callers driving the
+    // record/replay flow should set the same mode on every call. (A
+    // future enhancement could persist the mode in the run dir's
+    // manifest, but for now per-call is the documented contract.)
     const replayMode = resolveReplayMode({ "replay-mode": args["replay-mode"] });
+
+    const commit = runFsmCommit({ runId, outputs });
+    if (!commit.ok) {
+      fail(`fsm-commit failed: ${commit.error}`, { raw: commit.raw });
+    }
 
     // B7 record mode: persist the worker outputs we just received under
     // the hash key the runner stashed when it emitted awaiting_worker.
-    // Done BEFORE fsm-commit so a commit failure doesn't leave a
-    // half-recorded fixture without its corresponding env update.
+    // Done AFTER a successful fsm-commit so a commit failure (schema
+    // validation, post-validation, etc.) doesn't leave behind a stale
+    // fixture or wipe the pending-brief stash that a retry would need.
+    // Recording errors surface as a fault — silent failure here would
+    // make later replay-mode runs fail without a clear root cause.
     if (replayMode === "record") {
-      try {
-        const storageRoot = resolveStorageRoot();
-        const dir = runDirPath(runId, { storageRoot });
-        const stash = readPendingBrief(dir);
-        if (stash && typeof stash.state === "string" && typeof stash.hashKey === "string") {
+      const storageRoot = resolveStorageRoot();
+      const dir = runDirPath(runId, { storageRoot });
+      const stash = readPendingBrief(dir);
+      if (stash && typeof stash.state === "string" && typeof stash.hashKey === "string") {
+        try {
           recordOutputs(FIXTURES_ROOT, {
             state: stash.state,
             hashKey: stash.hashKey,
@@ -534,16 +562,15 @@ async function main() {
             meta: { recorded_at: new Date().toISOString(), run_id: runId },
           });
           clearPendingBrief(dir);
+        } catch (err) {
+          fail(
+            `replay-mode=record: failed to persist fixture for state=${stash.state}: ${err.message}`,
+            { state: stash.state, hash_key: stash.hashKey },
+          );
         }
-      } catch {
-        // Recording is opt-in instrumentation; never fail the run on it.
       }
     }
 
-    const commit = runFsmCommit({ runId, outputs });
-    if (!commit.ok) {
-      fail(`fsm-commit failed: ${commit.error}`, { raw: commit.raw });
-    }
     emit(await loop(commit.payload, runId, { replayMode }));
     return;
   }

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -81,10 +81,11 @@ export function repoRelativePromptPath(briefPath) {
   if (
     /(^|[\\/])\.\.([\\/]|$)/.test(briefPath) ||
     briefPath.startsWith("/") ||
+    briefPath.startsWith("\\") ||
     /^[A-Za-z]:[\\/]/.test(briefPath)
   ) {
     throw new Error(
-      `repoRelativePromptPath: traversal / absolute paths are rejected; got ${JSON.stringify(briefPath)}`,
+      `repoRelativePromptPath: traversal / absolute / UNC paths are rejected; got ${JSON.stringify(briefPath)}`,
     );
   }
   // Already repo-relative (starts with `fsm/`) → pass through unchanged.
@@ -592,8 +593,8 @@ async function main() {
     }
     const brief = start.payload;
     // Read replay-mode from the runner-level CLI flag only. Pulling it
-     // from argsBag would forward it into env.args (the FSM run env),
-     // which makes the worker hash differ between record vs replay.
+    // from argsBag would forward it into env.args (the FSM run env),
+    // which makes the worker hash differ between record vs replay.
     const replayMode = resolveReplayMode(
       { "replay-mode": args["replay-mode"] },
       {
@@ -625,13 +626,15 @@ async function main() {
     }
     const outputs = readJsonFile(outputsFile, "--outputs-file");
 
-    // --replay-mode must be passed on EACH --continue invocation. The
-    // runner is stateless across CLI calls; if --start was invoked with
-    // --replay-mode=record but a subsequent --continue omitted the flag,
-    // those outputs would silently NOT be recorded. Callers driving the
-    // record/replay flow should set the same mode on every call. (A
-    // future enhancement could persist the mode in the run dir's
-    // manifest, but for now per-call is the documented contract.)
+    // --replay-mode SHOULD be passed on EACH --continue invocation. The
+    // runner is stateless across CLI calls and the flag defaults to
+    // "live" when omitted; if --start was invoked with
+    // --replay-mode=record but a subsequent --continue omitted the
+    // flag, those outputs would silently NOT be recorded. Callers
+    // driving the record/replay flow should set the same mode on every
+    // call. (A future enhancement could persist the mode in the run
+    // dir's manifest so --continue infers it; for now per-call is the
+    // documented contract.)
     const replayMode = resolveReplayMode(
       { "replay-mode": args["replay-mode"] },
       {
@@ -694,8 +697,8 @@ async function main() {
 
   fail(
     "Usage:\n" +
-      "  run-review.mjs --start --base <sha> --head <sha> [--args-file <path>]\n" +
-      "  run-review.mjs --continue --run-id <id> --outputs-file <path>",
+      "  run-review.mjs --start --base <sha> --head <sha> [--args-file <path>] [--replay-mode <live|record|replay>]\n" +
+      "  run-review.mjs --continue --run-id <id> --outputs-file <path> [--replay-mode <live|record|replay>]",
   );
 }
 

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -418,6 +418,126 @@ async function dispatchInlineState(brief, runId) {
   }
 }
 
+// handleWorkerStateBrief — the worker-state branch of loop(), pulled out so
+// unit tests can drive replay-hit / replay-miss / replay-corrupted /
+// hash-fail / record-stash-fail without spinning up the FSM CLIs.
+//
+// Returns one of:
+//   { kind: "advance", payload: <new fsm-commit payload> }   — replay-hit auto-commit
+//   { kind: "pause",   payload: { status, run_id, brief } }   — emit awaiting_worker
+//   { kind: "fault",   payload: { status: "fault", run_id, fault } } — surface up
+//
+// `_deps` is the dependency injection seam (resolveStorageRoot, runEnv,
+// hashKeyForBrief, replayLookup, runFsmCommit, stashPendingBrief,
+// fixturesRoot, runDirPath). All have production defaults so the runner
+// can call this with no extra args.
+export function handleWorkerStateBrief(brief, runId, opts = {}, _deps = {}) {
+  const replayMode = opts.replayMode ?? "live";
+  const resolveStorageRootFn = _deps.resolveStorageRoot ?? resolveStorageRoot;
+  const runEnvFn = _deps.runEnv ?? runEnv;
+  const hashKeyForBriefFn = _deps.hashKeyForBrief ?? hashKeyForBrief;
+  const replayLookupFn = _deps.replayLookup ?? replayLookup;
+  const runFsmCommitFn = _deps.runFsmCommit ?? runFsmCommit;
+  const stashPendingBriefFn = _deps.stashPendingBrief ?? stashPendingBrief;
+  const runDirPathFn = _deps.runDirPath ?? runDirPath;
+  const fixturesRoot = _deps.fixturesRoot ?? FIXTURES_ROOT;
+
+  const storageRoot = resolveStorageRootFn();
+  const env = runEnvFn(runId, { storageRoot });
+
+  // hashKeyForBrief can throw when the prompt template is unreadable.
+  let hashKey;
+  try {
+    hashKey = hashKeyForBriefFn(brief, env);
+  } catch (err) {
+    return {
+      kind: "fault",
+      payload: {
+        status: "fault",
+        run_id: runId,
+        fault: {
+          state: brief.state,
+          reason: `hash key compute failed: ${err?.message ?? String(err)}`,
+        },
+      },
+    };
+  }
+
+  // B7 replay mode: try to satisfy the worker call from a recorded fixture.
+  if (replayMode === "replay") {
+    let cached;
+    try {
+      cached = replayLookupFn(fixturesRoot, brief.state, hashKey);
+    } catch (err) {
+      return {
+        kind: "fault",
+        payload: {
+          status: "fault",
+          run_id: runId,
+          fault: {
+            state: brief.state,
+            reason: `replay-mode fixture corrupted: ${err?.message ?? String(err)}`,
+            hash_key: hashKey,
+          },
+        },
+      };
+    }
+    if (cached === null) {
+      return {
+        kind: "fault",
+        payload: {
+          status: "fault",
+          run_id: runId,
+          fault: {
+            state: brief.state,
+            reason: `replay-mode miss: no fixture for state="${brief.state}" hashKey=${hashKey.slice(0, 12)}...`,
+            hash_key: hashKey,
+          },
+        },
+      };
+    }
+    const commit = runFsmCommitFn({ runId, outputs: cached });
+    if (!commit.ok) {
+      return {
+        kind: "fault",
+        payload: {
+          status: "fault",
+          run_id: runId,
+          fault: { state: brief.state, reason: commit.error, details: commit.raw },
+        },
+      };
+    }
+    return { kind: "advance", payload: commit.payload };
+  }
+
+  // B7 record / live: stash the brief for --continue. Record-mode failures
+  // surface; live-mode stash is best-effort.
+  const dir = runDirPathFn(runId, { storageRoot });
+  try {
+    stashPendingBriefFn(dir, { state: brief.state, hashKey });
+  } catch (err) {
+    if (replayMode === "record") {
+      return {
+        kind: "fault",
+        payload: {
+          status: "fault",
+          run_id: runId,
+          fault: {
+            state: brief.state,
+            reason: `replay-mode=record: failed to stash pending brief: ${err?.message ?? String(err)}`,
+          },
+        },
+      };
+    }
+    // Live mode: stash is best-effort bookkeeping; safe to ignore.
+  }
+
+  return {
+    kind: "pause",
+    payload: { status: "awaiting_worker", run_id: runId, brief },
+  };
+}
+
 // Drive the loop from a starting brief: walk inline states, pause on workers,
 // stop on terminal. Returns the final status payload to emit.
 async function loop(brief, runId, { replayMode = "live" } = {}) {
@@ -432,97 +552,13 @@ async function loop(brief, runId, { replayMode = "live" } = {}) {
       };
     }
     if (current.has_worker) {
-      const storageRoot = resolveStorageRoot();
-      const env = runEnv(runId, { storageRoot });
-      // hashKeyForBrief can throw when the prompt template is unreadable
-      // (a misconfigured FSM YAML). Convert to an in-flow fault for the
-      // current state instead of letting the exception bubble out as an
-      // unhandled top-level {status:"error"}.
-      let hashKey;
-      try {
-        hashKey = hashKeyForBrief(current, env);
-      } catch (err) {
-        return {
-          status: "fault",
-          run_id: runId,
-          fault: {
-            state: current.state,
-            reason: `hash key compute failed: ${err?.message ?? String(err)}`,
-          },
-        };
-      }
-
-      // B7 replay mode: try to satisfy the worker call from a recorded
-      // fixture. On hit, auto-commit the recorded outputs and continue
-      // the loop without ever emitting awaiting_worker. On miss, return
-      // a fault — silent fall-through to live dispatch would defeat the
-      // determinism the harness exists to provide.
-      if (replayMode === "replay") {
-        // replayLookup throws on corrupted/unreadable fixtures; convert
-        // those to in-flow faults so the run stops cleanly instead of
-        // crashing out as a top-level error.
-        let cached;
-        try {
-          cached = replayLookup(FIXTURES_ROOT, current.state, hashKey);
-        } catch (err) {
-          return {
-            status: "fault",
-            run_id: runId,
-            fault: {
-              state: current.state,
-              reason: `replay-mode fixture corrupted: ${err?.message ?? String(err)}`,
-              hash_key: hashKey,
-            },
-          };
-        }
-        if (cached === null) {
-          return {
-            status: "fault",
-            run_id: runId,
-            fault: {
-              state: current.state,
-              reason: `replay-mode miss: no fixture for state="${current.state}" hashKey=${hashKey.slice(0, 12)}...`,
-              hash_key: hashKey,
-            },
-          };
-        }
-        const commit = runFsmCommit({ runId, outputs: cached });
-        if (!commit.ok) {
-          return {
-            status: "fault",
-            run_id: runId,
-            fault: { state: current.state, reason: commit.error, details: commit.raw },
-          };
-        }
-        current = commit.payload;
+      const result = handleWorkerStateBrief(current, runId, { replayMode });
+      if (result.kind === "advance") {
+        current = result.payload;
         continue;
       }
-
-      // B7 record mode: stash the brief so --continue knows where to file
-      // the captured outputs. Live mode also stashes (cheap, harmless) so
-      // a subsequent --replay-mode=record on --continue still works
-      // without requiring the original --start to have set the flag.
-      // In RECORD mode the stash is load-bearing — without it --continue
-      // can't persist the fixture — so a stash failure under record-mode
-      // must surface, not get swallowed.
-      const dir = runDirPath(runId, { storageRoot });
-      try {
-        stashPendingBrief(dir, { state: current.state, hashKey });
-      } catch (err) {
-        if (replayMode === "record") {
-          return {
-            status: "fault",
-            run_id: runId,
-            fault: {
-              state: current.state,
-              reason: `replay-mode=record: failed to stash pending brief: ${err?.message ?? String(err)}`,
-            },
-          };
-        }
-        // Live mode: stash is best-effort bookkeeping; safe to ignore.
-      }
-
-      return { status: "awaiting_worker", run_id: runId, brief: current };
+      // "pause" (awaiting_worker) and "fault" both terminate this call.
+      return result.payload;
     }
     const dispatch = await dispatchInlineState(current, runId);
     if (!dispatch.ok) {

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -433,7 +433,23 @@ async function loop(brief, runId, { replayMode = "live" } = {}) {
     if (current.has_worker) {
       const storageRoot = resolveStorageRoot();
       const env = runEnv(runId, { storageRoot });
-      const hashKey = hashKeyForBrief(current, env);
+      // hashKeyForBrief can throw when the prompt template is unreadable
+      // (a misconfigured FSM YAML). Convert to an in-flow fault for the
+      // current state instead of letting the exception bubble out as an
+      // unhandled top-level {status:"error"}.
+      let hashKey;
+      try {
+        hashKey = hashKeyForBrief(current, env);
+      } catch (err) {
+        return {
+          status: "fault",
+          run_id: runId,
+          fault: {
+            state: current.state,
+            reason: `hash key compute failed: ${err?.message ?? String(err)}`,
+          },
+        };
+      }
 
       // B7 replay mode: try to satisfy the worker call from a recorded
       // fixture. On hit, auto-commit the recorded outputs and continue
@@ -441,7 +457,23 @@ async function loop(brief, runId, { replayMode = "live" } = {}) {
       // a fault — silent fall-through to live dispatch would defeat the
       // determinism the harness exists to provide.
       if (replayMode === "replay") {
-        const cached = replayLookup(FIXTURES_ROOT, current.state, hashKey);
+        // replayLookup throws on corrupted/unreadable fixtures; convert
+        // those to in-flow faults so the run stops cleanly instead of
+        // crashing out as a top-level error.
+        let cached;
+        try {
+          cached = replayLookup(FIXTURES_ROOT, current.state, hashKey);
+        } catch (err) {
+          return {
+            status: "fault",
+            run_id: runId,
+            fault: {
+              state: current.state,
+              reason: `replay-mode fixture corrupted: ${err?.message ?? String(err)}`,
+              hash_key: hashKey,
+            },
+          };
+        }
         if (cached === null) {
           return {
             status: "fault",
@@ -469,11 +501,24 @@ async function loop(brief, runId, { replayMode = "live" } = {}) {
       // the captured outputs. Live mode also stashes (cheap, harmless) so
       // a subsequent --replay-mode=record on --continue still works
       // without requiring the original --start to have set the flag.
+      // In RECORD mode the stash is load-bearing — without it --continue
+      // can't persist the fixture — so a stash failure under record-mode
+      // must surface, not get swallowed.
       const dir = runDirPath(runId, { storageRoot });
       try {
         stashPendingBrief(dir, { state: current.state, hashKey });
-      } catch {
-        // Stash is best-effort bookkeeping; never fail the run on it.
+      } catch (err) {
+        if (replayMode === "record") {
+          return {
+            status: "fault",
+            run_id: runId,
+            fault: {
+              state: current.state,
+              reason: `replay-mode=record: failed to stash pending brief: ${err?.message ?? String(err)}`,
+            },
+          };
+        }
+        // Live mode: stash is best-effort bookkeeping; safe to ignore.
       }
 
       return { status: "awaiting_worker", run_id: runId, brief: current };
@@ -612,8 +657,9 @@ async function main() {
       const stash = readPendingBrief(dir);
       // No silent skip: a missing/malformed stash means the user thinks
       // they are recording fixtures but nothing would land on disk.
-      // Surface as a structured fault so the harness fails loud, not
-      // quiet — that is the entire point of record mode.
+      // Surface via fail() so the run stops loud (emits {status:"error"}
+      // and exits non-zero) — silent record-mode would be worse than no
+      // record mode at all.
       if (!(stash && typeof stash.state === "string" && typeof stash.hashKey === "string")) {
         fail(
           "replay-mode=record: missing or invalid pending-brief stash; cannot persist fixture",

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -442,6 +442,21 @@ export function handleWorkerStateBrief(brief, runId, opts = {}, _deps = {}) {
   const runDirPathFn = _deps.runDirPath ?? runDirPath;
   const fixturesRoot = _deps.fixturesRoot ?? FIXTURES_ROOT;
 
+  // Live mode (the default) skips the env+hash+stash work entirely. The
+  // hash key and stash only matter for replay/record; running them on
+  // every live worker pause introduces new failure modes (unreadable
+  // prompt template, missing run-storage) for callers who didn't
+  // opt into the harness. The trade-off: a user who goes
+  // `--start --replay-mode=live` and then `--continue
+  // --replay-mode=record` will not have a stash to record against;
+  // record mode is per-run, not retroactive.
+  if (replayMode === "live") {
+    return {
+      kind: "pause",
+      payload: { status: "awaiting_worker", run_id: runId, brief },
+    };
+  }
+
   // resolveStorageRoot reads .fsmrc.json + walks @ctxr/fsm config; runEnv
   // reads the run-storage tree on disk. Either can throw on a missing /
   // corrupt config or storage. Convert to an in-flow fault so the run
@@ -529,26 +544,25 @@ export function handleWorkerStateBrief(brief, runId, opts = {}, _deps = {}) {
     return { kind: "advance", payload: commit.payload };
   }
 
-  // B7 record / live: stash the brief for --continue. Record-mode failures
-  // surface; live-mode stash is best-effort.
+  // B7 record mode: stash the brief for --continue. Stash failures
+  // surface as faults — without the stash, --continue can't persist
+  // the recorded fixture and the user would think record-mode
+  // succeeded when it silently didn't. (Live mode returned early.)
   const dir = runDirPathFn(runId, { storageRoot });
   try {
     stashPendingBriefFn(dir, { state: brief.state, hashKey });
   } catch (err) {
-    if (replayMode === "record") {
-      return {
-        kind: "fault",
-        payload: {
-          status: "fault",
-          run_id: runId,
-          fault: {
-            state: brief.state,
-            reason: `replay-mode=record: failed to stash pending brief: ${err?.message ?? String(err)}`,
-          },
+    return {
+      kind: "fault",
+      payload: {
+        status: "fault",
+        run_id: runId,
+        fault: {
+          state: brief.state,
+          reason: `replay-mode=record: failed to stash pending brief: ${err?.message ?? String(err)}`,
         },
-      };
-    }
-    // Live mode: stash is best-effort bookkeeping; safe to ignore.
+      },
+    };
   }
 
   return {
@@ -710,9 +724,21 @@ async function main() {
     // Recording errors surface as a fault — silent failure here would
     // make later replay-mode runs fail without a clear root cause.
     if (replayMode === "record") {
-      const storageRoot = resolveStorageRoot();
-      const dir = runDirPath(runId, { storageRoot });
-      const stash = readPendingBrief(dir);
+      // resolveStorageRoot / runDirPath / readPendingBrief can throw on
+      // a missing or corrupt .fsmrc.json or a missing run-storage tree.
+      // Wrap in try/catch so the record-mode finalisation surfaces a
+      // structured error instead of falling through to main().catch.
+      let storageRoot, dir, stash;
+      try {
+        storageRoot = resolveStorageRoot();
+        dir = runDirPath(runId, { storageRoot });
+        stash = readPendingBrief(dir);
+      } catch (err) {
+        fail(
+          `replay-mode=record: failed to read run state for fixture persistence: ${err?.message ?? String(err)}`,
+          { run_id: runId },
+        );
+      }
       // No silent skip: a missing/malformed stash means the user thinks
       // they are recording fixtures but nothing would land on disk.
       // Surface via fail() so the run stops loud (emits {status:"error"}

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -524,10 +524,6 @@ async function main() {
     }
     const outputs = readJsonFile(outputsFile, "--outputs-file");
 
-    // B8 referential-integrity check (extracted into runTrimValidationGate
-    // so unit tests can exercise it without a live runner).
-    runTrimValidationGate(runId, outputs);
-
     // --replay-mode must be passed on EACH --continue invocation. The
     // runner is stateless across CLI calls; if --start was invoked with
     // --replay-mode=record but a subsequent --continue omitted the flag,
@@ -553,21 +549,29 @@ async function main() {
       const storageRoot = resolveStorageRoot();
       const dir = runDirPath(runId, { storageRoot });
       const stash = readPendingBrief(dir);
-      if (stash && typeof stash.state === "string" && typeof stash.hashKey === "string") {
-        try {
-          recordOutputs(FIXTURES_ROOT, {
-            state: stash.state,
-            hashKey: stash.hashKey,
-            outputs,
-            meta: { recorded_at: new Date().toISOString(), run_id: runId },
-          });
-          clearPendingBrief(dir);
-        } catch (err) {
-          fail(
-            `replay-mode=record: failed to persist fixture for state=${stash.state}: ${err.message}`,
-            { state: stash.state, hash_key: stash.hashKey },
-          );
-        }
+      // No silent skip: a missing/malformed stash means the user thinks
+      // they are recording fixtures but nothing would land on disk.
+      // Surface as a structured fault so the harness fails loud, not
+      // quiet — that is the entire point of record mode.
+      if (!(stash && typeof stash.state === "string" && typeof stash.hashKey === "string")) {
+        fail(
+          "replay-mode=record: missing or invalid pending-brief stash; cannot persist fixture",
+          { run_id: runId, dir },
+        );
+      }
+      try {
+        recordOutputs(FIXTURES_ROOT, {
+          state: stash.state,
+          hashKey: stash.hashKey,
+          outputs,
+          meta: { recorded_at: new Date().toISOString(), run_id: runId },
+        });
+        clearPendingBrief(dir);
+      } catch (err) {
+        fail(
+          `replay-mode=record: failed to persist fixture for state=${stash.state}: ${err.message}`,
+          { state: stash.state, hash_key: stash.hashKey },
+        );
       }
     }
 

--- a/tests/integration/replay-mode.test.js
+++ b/tests/integration/replay-mode.test.js
@@ -66,7 +66,7 @@ test("integration: record → two replays produce identical outputs (parsed and 
     const a = replayLookup(fixturesRoot, "llm_trim", hashKey);
     const b = replayLookup(fixturesRoot, "llm_trim", hashKey);
     assert.deepEqual(a, b, "two replays must agree (parsed)");
-    assert.deepEqual(a, recordedOutputs);
+    assert.deepEqual(a, { hit: true, outputs: recordedOutputs });
 
     // Byte-level stability: re-record the same fixture with keys in a
     // different insertion order and confirm the on-disk file is
@@ -101,7 +101,7 @@ test("integration: prompt content edit invalidates the recorded hash", () => {
       hashKey: hashV1,
       outputs: { picked_leaves: [], rejected_leaves: [], coverage_rescues: [] },
     });
-    assert.ok(replayLookup(fixturesRoot, "llm_trim", hashV1));
+    assert.equal(replayLookup(fixturesRoot, "llm_trim", hashV1).hit, true);
 
     // Edit the prompt body — the path is the same, but the content
     // changed, so the hash MUST change. Same inputs, same state, same
@@ -113,9 +113,9 @@ test("integration: prompt content edit invalidates the recorded hash", () => {
     );
     const hashV2 = computeHashKey({ state: "llm_trim", promptTemplate, inputs, repoRoot });
     assert.notEqual(hashV1, hashV2, "hash must change when the prompt body changes");
-    assert.equal(
+    assert.deepEqual(
       replayLookup(fixturesRoot, "llm_trim", hashV2),
-      null,
+      { hit: false },
       "prompt drift must produce a replay miss, not a stale hit",
     );
   } finally {
@@ -144,7 +144,7 @@ test("integration: input change → different hash → replay miss", () => {
       repoRoot,
     });
     assert.notEqual(hashA, hashB);
-    assert.equal(replayLookup(fixturesRoot, "llm_trim", hashB), null);
+    assert.deepEqual(replayLookup(fixturesRoot, "llm_trim", hashB), { hit: false });
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
   }

--- a/tests/integration/replay-mode.test.js
+++ b/tests/integration/replay-mode.test.js
@@ -1,0 +1,134 @@
+// Integration test for the B7 record/replay harness end-to-end.
+//
+// We exercise the harness's record→replay round-trip without a live
+// runner spawn (which would require @ctxr/fsm CLIs + a worker dispatcher
+// in the loop). The harness's contract is purely "given the same hash
+// key, replay returns byte-identical fixture content"; this integration
+// test seeds two fixtures via the public record API and asserts replay
+// reproduces them across two consecutive lookups, mirroring the issue's
+// acceptance criteria ("invoke the runner twice in replay mode against
+// the recorded fixtures; assert identical end-state").
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  computeHashKey,
+  recordOutputs,
+  replayLookup,
+} from "../../scripts/lib/worker-replay.mjs";
+
+function makeTmpRepo() {
+  const root = mkdtempSync(join(tmpdir(), "replay-mode-int-"));
+  // Mirror just enough of the repo layout that prompt-content-hashing
+  // works: write a fake prompt template under fsm/workers/.
+  mkdirSync(join(root, "fsm", "workers"), { recursive: true });
+  writeFileSync(
+    join(root, "fsm", "workers", "trim-candidates.md"),
+    "# trim-candidates\nbody v1\n",
+  );
+  return root;
+}
+
+test("integration: record → two replays produce byte-identical outputs", () => {
+  const repoRoot = makeTmpRepo();
+  const fixturesRoot = join(repoRoot, "fixtures");
+  try {
+    const inputs = {
+      tier: "sensitive",
+      cap: 30,
+      stage_a_candidates: [
+        { id: "lang-typescript", path: "lang-typescript.md", activation_match: ["file_globs"] },
+        { id: "sec-csrf", path: "sec-csrf.md", activation_match: ["file_globs"] },
+      ],
+    };
+    const hashKey = computeHashKey({
+      state: "llm_trim",
+      promptTemplate: "fsm/workers/trim-candidates.md",
+      inputs,
+      repoRoot,
+    });
+
+    const recordedOutputs = {
+      picked_leaves: [
+        { id: "lang-typescript", path: "lang-typescript.md", justification: "ts present", dimensions: ["correctness"] },
+      ],
+      rejected_leaves: [{ id: "sec-csrf", reason: "no http handlers in diff" }],
+      coverage_rescues: [],
+    };
+
+    recordOutputs(fixturesRoot, { state: "llm_trim", hashKey, outputs: recordedOutputs });
+
+    const a = replayLookup(fixturesRoot, "llm_trim", hashKey);
+    const b = replayLookup(fixturesRoot, "llm_trim", hashKey);
+    assert.deepEqual(a, b, "two replays must be byte-identical");
+    assert.deepEqual(a, recordedOutputs);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("integration: prompt content edit invalidates the recorded hash", () => {
+  const repoRoot = makeTmpRepo();
+  const fixturesRoot = join(repoRoot, "fixtures");
+  try {
+    const inputs = { tier: "lite", cap: 8, stage_a_candidates: [] };
+    const promptTemplate = "fsm/workers/trim-candidates.md";
+
+    const hashV1 = computeHashKey({ state: "llm_trim", promptTemplate, inputs, repoRoot });
+    recordOutputs(fixturesRoot, {
+      state: "llm_trim",
+      hashKey: hashV1,
+      outputs: { picked_leaves: [], rejected_leaves: [], coverage_rescues: [] },
+    });
+    assert.ok(replayLookup(fixturesRoot, "llm_trim", hashV1));
+
+    // Edit the prompt body — the path is the same, but the content
+    // changed, so the hash MUST change. Same inputs, same state, same
+    // path, different prompt body ⇒ replay-mode fixture for the old
+    // prompt is no longer hit.
+    writeFileSync(
+      join(repoRoot, "fsm", "workers", "trim-candidates.md"),
+      "# trim-candidates\nbody v2 — semantic change\n",
+    );
+    const hashV2 = computeHashKey({ state: "llm_trim", promptTemplate, inputs, repoRoot });
+    assert.notEqual(hashV1, hashV2, "hash must change when the prompt body changes");
+    assert.equal(
+      replayLookup(fixturesRoot, "llm_trim", hashV2),
+      null,
+      "prompt drift must produce a replay miss, not a stale hit",
+    );
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("integration: input change → different hash → replay miss", () => {
+  const repoRoot = makeTmpRepo();
+  const fixturesRoot = join(repoRoot, "fixtures");
+  try {
+    const baseInputs = { tier: "sensitive", cap: 30, stage_a_candidates: [{ id: "a" }] };
+    const promptTemplate = "fsm/workers/trim-candidates.md";
+
+    const hashA = computeHashKey({ state: "llm_trim", promptTemplate, inputs: baseInputs, repoRoot });
+    recordOutputs(fixturesRoot, {
+      state: "llm_trim",
+      hashKey: hashA,
+      outputs: { picked_leaves: [{ id: "a" }] },
+    });
+
+    const hashB = computeHashKey({
+      state: "llm_trim",
+      promptTemplate,
+      inputs: { ...baseInputs, tier: "full" }, // one field flipped
+      repoRoot,
+    });
+    assert.notEqual(hashA, hashB);
+    assert.equal(replayLookup(fixturesRoot, "llm_trim", hashB), null);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/replay-mode.test.js
+++ b/tests/integration/replay-mode.test.js
@@ -2,21 +2,22 @@
 //
 // We exercise the harness's record→replay round-trip without a live
 // runner spawn (which would require @ctxr/fsm CLIs + a worker dispatcher
-// in the loop). The harness's contract is purely "given the same hash
-// key, replay returns byte-identical fixture content"; this integration
-// test seeds two fixtures via the public record API and asserts replay
-// reproduces them across two consecutive lookups, mirroring the issue's
-// acceptance criteria ("invoke the runner twice in replay mode against
-// the recorded fixtures; assert identical end-state").
+// in the loop). The harness's contract is "given the same hash key,
+// replay returns byte-identical fixture content"; this integration test
+// seeds a fixture via the public record API and asserts replay
+// reproduces it across two consecutive lookups (parsed equality) AND
+// that the on-disk fixture is byte-stable when re-recorded with
+// reordered keys, mirroring the issue's acceptance criteria.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
   computeHashKey,
+  fixturePath,
   recordOutputs,
   replayLookup,
 } from "../../scripts/lib/worker-replay.mjs";
@@ -33,7 +34,7 @@ function makeTmpRepo() {
   return root;
 }
 
-test("integration: record → two replays produce byte-identical outputs", () => {
+test("integration: record → two replays produce identical outputs (parsed and on-disk byte-stable)", () => {
   const repoRoot = makeTmpRepo();
   const fixturesRoot = join(repoRoot, "fixtures");
   try {
@@ -64,8 +65,24 @@ test("integration: record → two replays produce byte-identical outputs", () =>
 
     const a = replayLookup(fixturesRoot, "llm_trim", hashKey);
     const b = replayLookup(fixturesRoot, "llm_trim", hashKey);
-    assert.deepEqual(a, b, "two replays must be byte-identical");
+    assert.deepEqual(a, b, "two replays must agree (parsed)");
     assert.deepEqual(a, recordedOutputs);
+
+    // Byte-level stability: re-record the same fixture with keys in a
+    // different insertion order and confirm the on-disk file is
+    // byte-identical (canonicalization sorts keys).
+    const reordered = {
+      coverage_rescues: [],
+      rejected_leaves: [{ reason: "no http handlers in diff", id: "sec-csrf" }],
+      picked_leaves: [
+        { dimensions: ["correctness"], path: "lang-typescript.md", id: "lang-typescript", justification: "ts present" },
+      ],
+    };
+    const path1 = fixturePath(fixturesRoot, "llm_trim", hashKey);
+    const bytes1 = readFileSync(path1);
+    recordOutputs(fixturesRoot, { state: "llm_trim", hashKey, outputs: reordered });
+    const bytes2 = readFileSync(path1);
+    assert.equal(bytes1.equals(bytes2), true, "on-disk fixture must be byte-identical after reorder");
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
   }

--- a/tests/unit/run-review.test.js
+++ b/tests/unit/run-review.test.js
@@ -13,6 +13,7 @@ import {
   stateIdToModuleName,
   isValidGitRef,
   repoRelativePromptPath,
+  handleWorkerStateBrief,
 } from "../../scripts/run-review.mjs";
 
 test("parseArgs: --flag value pairs become entries", () => {
@@ -147,6 +148,141 @@ test("repoRelativePromptPath: rejects path traversal and absolute paths", () => 
   // which escapes the intended repo-relative scope.
   assert.throws(() => repoRelativePromptPath("\\Windows\\System32"), /traversal|absolute|UNC/);
   assert.throws(() => repoRelativePromptPath("\\\\server\\share\\file"), /traversal|absolute|UNC/);
+});
+
+test("handleWorkerStateBrief: replay HIT auto-commits and advances", () => {
+  // Replay returns a recorded fixture; the helper must run fsm-commit
+  // and return kind:"advance" with the new payload, never emitting
+  // awaiting_worker on a hit.
+  const fakeBrief = { state: "llm_trim", has_worker: true };
+  const recordedOutputs = { picked_leaves: [], rejected_leaves: [], coverage_rescues: [] };
+  const result = handleWorkerStateBrief(
+    fakeBrief,
+    "run-1",
+    { replayMode: "replay" },
+    {
+      resolveStorageRoot: () => "/tmp",
+      runEnv: () => ({}),
+      hashKeyForBrief: () => "a".repeat(64),
+      replayLookup: () => recordedOutputs,
+      runFsmCommit: ({ runId, outputs }) => {
+        assert.equal(runId, "run-1");
+        assert.deepEqual(outputs, recordedOutputs);
+        return { ok: true, payload: { state: "next-state", has_worker: false } };
+      },
+      stashPendingBrief: () => {},
+      runDirPath: () => "/tmp/run",
+      fixturesRoot: "/tmp/fixtures",
+    },
+  );
+  assert.equal(result.kind, "advance");
+  assert.equal(result.payload.state, "next-state");
+});
+
+test("handleWorkerStateBrief: replay MISS faults with hash_key in details", () => {
+  const result = handleWorkerStateBrief(
+    { state: "llm_trim", has_worker: true },
+    "run-1",
+    { replayMode: "replay" },
+    {
+      resolveStorageRoot: () => "/tmp",
+      runEnv: () => ({}),
+      hashKeyForBrief: () => "b".repeat(64),
+      replayLookup: () => null,
+      runFsmCommit: () => assert.fail("must not commit on a miss"),
+      stashPendingBrief: () => {},
+      runDirPath: () => "/tmp/run",
+      fixturesRoot: "/tmp/fixtures",
+    },
+  );
+  assert.equal(result.kind, "fault");
+  assert.equal(result.payload.status, "fault");
+  assert.match(result.payload.fault.reason, /replay-mode miss/);
+  assert.equal(result.payload.fault.hash_key, "b".repeat(64));
+});
+
+test("handleWorkerStateBrief: replay corrupted fixture surfaces as fault, not crash", () => {
+  const result = handleWorkerStateBrief(
+    { state: "llm_trim", has_worker: true },
+    "run-1",
+    { replayMode: "replay" },
+    {
+      resolveStorageRoot: () => "/tmp",
+      runEnv: () => ({}),
+      hashKeyForBrief: () => "c".repeat(64),
+      replayLookup: () => { throw new Error("invalid JSON in fixture"); },
+      runFsmCommit: () => assert.fail("must not commit when lookup throws"),
+      stashPendingBrief: () => {},
+      runDirPath: () => "/tmp/run",
+      fixturesRoot: "/tmp/fixtures",
+    },
+  );
+  assert.equal(result.kind, "fault");
+  assert.match(result.payload.fault.reason, /fixture corrupted/);
+});
+
+test("handleWorkerStateBrief: hash compute failure surfaces as in-flow fault", () => {
+  const result = handleWorkerStateBrief(
+    { state: "llm_trim", has_worker: true },
+    "run-1",
+    { replayMode: "live" },
+    {
+      resolveStorageRoot: () => "/tmp",
+      runEnv: () => ({}),
+      hashKeyForBrief: () => { throw new Error("prompt template not readable"); },
+      replayLookup: () => assert.fail("must not look up when hash fails"),
+      runFsmCommit: () => assert.fail("must not commit"),
+      stashPendingBrief: () => {},
+      runDirPath: () => "/tmp/run",
+      fixturesRoot: "/tmp/fixtures",
+    },
+  );
+  assert.equal(result.kind, "fault");
+  assert.match(result.payload.fault.reason, /hash key compute failed/);
+});
+
+test("handleWorkerStateBrief: record-mode stash failure surfaces as fault", () => {
+  const result = handleWorkerStateBrief(
+    { state: "llm_trim", has_worker: true },
+    "run-1",
+    { replayMode: "record" },
+    {
+      resolveStorageRoot: () => "/tmp",
+      runEnv: () => ({}),
+      hashKeyForBrief: () => "d".repeat(64),
+      replayLookup: () => null,
+      runFsmCommit: () => assert.fail("must not commit"),
+      stashPendingBrief: () => { throw new Error("disk full"); },
+      runDirPath: () => "/tmp/run",
+      fixturesRoot: "/tmp/fixtures",
+    },
+  );
+  assert.equal(result.kind, "fault");
+  assert.match(result.payload.fault.reason, /failed to stash pending brief/);
+});
+
+test("handleWorkerStateBrief: live-mode pauses with awaiting_worker even when stash fails", () => {
+  // Stash is best-effort in live mode; a write failure must NOT abort
+  // the run. The helper still returns kind:"pause" / awaiting_worker.
+  const brief = { state: "llm_trim", has_worker: true };
+  const result = handleWorkerStateBrief(
+    brief,
+    "run-1",
+    { replayMode: "live" },
+    {
+      resolveStorageRoot: () => "/tmp",
+      runEnv: () => ({}),
+      hashKeyForBrief: () => "e".repeat(64),
+      replayLookup: () => null,
+      runFsmCommit: () => assert.fail("must not commit"),
+      stashPendingBrief: () => { throw new Error("disk full"); },
+      runDirPath: () => "/tmp/run",
+      fixturesRoot: "/tmp/fixtures",
+    },
+  );
+  assert.equal(result.kind, "pause");
+  assert.equal(result.payload.status, "awaiting_worker");
+  assert.equal(result.payload.brief, brief);
 });
 
 test("isValidGitRef: rejects shell metacharacters, leading dash, overlong", () => {

--- a/tests/unit/run-review.test.js
+++ b/tests/unit/run-review.test.js
@@ -120,11 +120,27 @@ test("repoRelativePromptPath: projects FSM-yaml-relative paths to repo-relative 
     repoRelativePromptPath("workers/trim-candidates.md"),
     "fsm/workers/trim-candidates.md",
   );
+  // Already repo-relative → pass through unchanged.
+  assert.equal(
+    repoRelativePromptPath("fsm/workers/trim-candidates.md"),
+    "fsm/workers/trim-candidates.md",
+  );
   // Empty / non-string inputs project to the empty string (the harness
   // treats that as "no prompt body" and only hashes the path component).
   assert.equal(repoRelativePromptPath(""), "");
   assert.equal(repoRelativePromptPath(null), "");
   assert.equal(repoRelativePromptPath(undefined), "");
+});
+
+test("repoRelativePromptPath: rejects path traversal and absolute paths", () => {
+  // The hashing harness reads `<repoRoot>/<promptTemplate>`; without
+  // these guards a tampered FSM YAML could pull arbitrary files into
+  // the recorded fixture's content fingerprint.
+  assert.throws(() => repoRelativePromptPath("../etc/passwd"), /traversal/);
+  assert.throws(() => repoRelativePromptPath("workers/../../etc/passwd"), /traversal/);
+  assert.throws(() => repoRelativePromptPath("/etc/passwd"), /absolute/);
+  assert.throws(() => repoRelativePromptPath("C:\\Windows\\System32"), /absolute/);
+  assert.throws(() => repoRelativePromptPath("..\\evil.md"), /traversal/);
 });
 
 test("isValidGitRef: rejects shell metacharacters, leading dash, overlong", () => {

--- a/tests/unit/run-review.test.js
+++ b/tests/unit/run-review.test.js
@@ -136,11 +136,17 @@ test("repoRelativePromptPath: rejects path traversal and absolute paths", () => 
   // The hashing harness reads `<repoRoot>/<promptTemplate>`; without
   // these guards a tampered FSM YAML could pull arbitrary files into
   // the recorded fixture's content fingerprint.
-  assert.throws(() => repoRelativePromptPath("../etc/passwd"), /traversal/);
-  assert.throws(() => repoRelativePromptPath("workers/../../etc/passwd"), /traversal/);
-  assert.throws(() => repoRelativePromptPath("/etc/passwd"), /absolute/);
-  assert.throws(() => repoRelativePromptPath("C:\\Windows\\System32"), /absolute/);
-  assert.throws(() => repoRelativePromptPath("..\\evil.md"), /traversal/);
+  assert.throws(() => repoRelativePromptPath("../etc/passwd"), /traversal|absolute/);
+  assert.throws(() => repoRelativePromptPath("workers/../../etc/passwd"), /traversal|absolute/);
+  assert.throws(() => repoRelativePromptPath("/etc/passwd"), /traversal|absolute/);
+  assert.throws(() => repoRelativePromptPath("C:\\Windows\\System32"), /traversal|absolute/);
+  assert.throws(() => repoRelativePromptPath("..\\evil.md"), /traversal|absolute/);
+  // Windows leading-backslash and UNC forms must also be rejected:
+  // `\Windows\...` and `\\server\share\...` get normalized into
+  // `<repoRoot>\Windows\...` / similar by path.resolve on Windows,
+  // which escapes the intended repo-relative scope.
+  assert.throws(() => repoRelativePromptPath("\\Windows\\System32"), /traversal|absolute|UNC/);
+  assert.throws(() => repoRelativePromptPath("\\\\server\\share\\file"), /traversal|absolute|UNC/);
 });
 
 test("isValidGitRef: rejects shell metacharacters, leading dash, overlong", () => {

--- a/tests/unit/run-review.test.js
+++ b/tests/unit/run-review.test.js
@@ -12,6 +12,7 @@ import {
   parseFsmCliResult,
   stateIdToModuleName,
   isValidGitRef,
+  repoRelativePromptPath,
 } from "../../scripts/run-review.mjs";
 
 test("parseArgs: --flag value pairs become entries", () => {
@@ -104,6 +105,26 @@ test("isValidGitRef: accepts SHAs, branches, tags, revspecs", () => {
   assert.equal(isValidGitRef("HEAD^"), true);
   assert.equal(isValidGitRef("commit^2"), true);
   assert.equal(isValidGitRef("branch@{1.day.ago}"), true);
+});
+
+test("repoRelativePromptPath: projects FSM-yaml-relative paths to repo-relative ones", () => {
+  // brief.prompt_template values are relative to the FSM YAML's own
+  // directory (e.g. `workers/project-scanner.md`). The hashing harness
+  // expects repo-relative paths (`fsm/workers/project-scanner.md`) so
+  // it can read the prompt body. This pure helper does the projection.
+  assert.equal(
+    repoRelativePromptPath("workers/project-scanner.md"),
+    "fsm/workers/project-scanner.md",
+  );
+  assert.equal(
+    repoRelativePromptPath("workers/trim-candidates.md"),
+    "fsm/workers/trim-candidates.md",
+  );
+  // Empty / non-string inputs project to the empty string (the harness
+  // treats that as "no prompt body" and only hashes the path component).
+  assert.equal(repoRelativePromptPath(""), "");
+  assert.equal(repoRelativePromptPath(null), "");
+  assert.equal(repoRelativePromptPath(undefined), "");
 });
 
 test("isValidGitRef: rejects shell metacharacters, leading dash, overlong", () => {

--- a/tests/unit/run-review.test.js
+++ b/tests/unit/run-review.test.js
@@ -150,6 +150,30 @@ test("repoRelativePromptPath: rejects path traversal and absolute paths", () => 
   assert.throws(() => repoRelativePromptPath("\\\\server\\share\\file"), /traversal|absolute|UNC/);
 });
 
+test("handleWorkerStateBrief: env-loader failure surfaces as in-flow fault, not crash", () => {
+  // resolveStorageRoot reads .fsmrc.json + fsm config; runEnv reads
+  // run-storage on disk. Either can throw on a missing/corrupt config
+  // or storage tree. The helper must wrap them so failures convert to
+  // {kind:"fault"} instead of bubbling out as a top-level error.
+  const result = handleWorkerStateBrief(
+    { state: "llm_trim", has_worker: true },
+    "run-1",
+    { replayMode: "live" },
+    {
+      resolveStorageRoot: () => { throw new Error("fsm config missing"); },
+      runEnv: () => assert.fail("must not reach runEnv when resolveStorageRoot threw"),
+      hashKeyForBrief: () => assert.fail("must not reach hashKey"),
+      replayLookup: () => assert.fail("must not reach replay"),
+      runFsmCommit: () => assert.fail("must not commit"),
+      stashPendingBrief: () => {},
+      runDirPath: () => "/tmp/run",
+      fixturesRoot: "/tmp/fixtures",
+    },
+  );
+  assert.equal(result.kind, "fault");
+  assert.match(result.payload.fault.reason, /failed to load run env/);
+});
+
 test("handleWorkerStateBrief: replay HIT auto-commits and advances", () => {
   // Replay returns a recorded fixture; the helper must run fsm-commit
   // and return kind:"advance" with the new payload, never emitting
@@ -164,7 +188,7 @@ test("handleWorkerStateBrief: replay HIT auto-commits and advances", () => {
       resolveStorageRoot: () => "/tmp",
       runEnv: () => ({}),
       hashKeyForBrief: () => "a".repeat(64),
-      replayLookup: () => recordedOutputs,
+      replayLookup: () => ({ hit: true, outputs: recordedOutputs }),
       runFsmCommit: ({ runId, outputs }) => {
         assert.equal(runId, "run-1");
         assert.deepEqual(outputs, recordedOutputs);
@@ -188,7 +212,7 @@ test("handleWorkerStateBrief: replay MISS faults with hash_key in details", () =
       resolveStorageRoot: () => "/tmp",
       runEnv: () => ({}),
       hashKeyForBrief: () => "b".repeat(64),
-      replayLookup: () => null,
+      replayLookup: () => ({ hit: false }),
       runFsmCommit: () => assert.fail("must not commit on a miss"),
       stashPendingBrief: () => {},
       runDirPath: () => "/tmp/run",
@@ -250,7 +274,7 @@ test("handleWorkerStateBrief: record-mode stash failure surfaces as fault", () =
       resolveStorageRoot: () => "/tmp",
       runEnv: () => ({}),
       hashKeyForBrief: () => "d".repeat(64),
-      replayLookup: () => null,
+      replayLookup: () => ({ hit: false }),
       runFsmCommit: () => assert.fail("must not commit"),
       stashPendingBrief: () => { throw new Error("disk full"); },
       runDirPath: () => "/tmp/run",
@@ -273,7 +297,7 @@ test("handleWorkerStateBrief: live-mode pauses with awaiting_worker even when st
       resolveStorageRoot: () => "/tmp",
       runEnv: () => ({}),
       hashKeyForBrief: () => "e".repeat(64),
-      replayLookup: () => null,
+      replayLookup: () => ({ hit: false }),
       runFsmCommit: () => assert.fail("must not commit"),
       stashPendingBrief: () => { throw new Error("disk full"); },
       runDirPath: () => "/tmp/run",

--- a/tests/unit/run-review.test.js
+++ b/tests/unit/run-review.test.js
@@ -37,6 +37,12 @@ test("parseArgs: bare --flag (no value) becomes boolean true", () => {
   assert.equal(args.continue, true);
 });
 
+test("parseArgs: supports --key=value syntax in addition to --key value", () => {
+  const args = parseArgs(["node", "run-review.mjs", "--replay-mode=record", "--base=abc"]);
+  assert.equal(args["replay-mode"], "record");
+  assert.equal(args.base, "abc");
+});
+
 test("parseArgs: ignores positional args before --", () => {
   const args = parseArgs(["node", "run-review.mjs", "extra", "--key", "v"]);
   assert.equal(args.key, "v");

--- a/tests/unit/run-review.test.js
+++ b/tests/unit/run-review.test.js
@@ -268,6 +268,30 @@ test("handleWorkerStateBrief: hash compute failure (record mode) surfaces as in-
   assert.match(result.payload.fault.reason, /hash key compute failed/);
 });
 
+test("handleWorkerStateBrief: record-mode runDirPath failure surfaces as fault (not crash)", () => {
+  // runDirPath touches the run-storage tree on disk. A missing /
+  // corrupt storage tree would throw — the helper must convert that
+  // to a structured fault instead of letting it bubble out as a
+  // top-level error.
+  const result = handleWorkerStateBrief(
+    { state: "llm_trim", has_worker: true },
+    "run-1",
+    { replayMode: "record" },
+    {
+      resolveStorageRoot: () => "/tmp",
+      runEnv: () => ({}),
+      hashKeyForBrief: () => "f".repeat(64),
+      replayLookup: () => ({ hit: false }),
+      runFsmCommit: () => assert.fail("must not commit"),
+      stashPendingBrief: () => assert.fail("must not stash when runDirPath threw"),
+      runDirPath: () => { throw new Error("storage tree missing"); },
+      fixturesRoot: "/tmp/fixtures",
+    },
+  );
+  assert.equal(result.kind, "fault");
+  assert.match(result.payload.fault.reason, /failed to stash pending brief/);
+});
+
 test("handleWorkerStateBrief: record-mode stash failure surfaces as fault", () => {
   const result = handleWorkerStateBrief(
     { state: "llm_trim", has_worker: true },

--- a/tests/unit/run-review.test.js
+++ b/tests/unit/run-review.test.js
@@ -158,7 +158,7 @@ test("handleWorkerStateBrief: env-loader failure surfaces as in-flow fault, not 
   const result = handleWorkerStateBrief(
     { state: "llm_trim", has_worker: true },
     "run-1",
-    { replayMode: "live" },
+    { replayMode: "record" }, // live mode skips env loading entirely
     {
       resolveStorageRoot: () => { throw new Error("fsm config missing"); },
       runEnv: () => assert.fail("must not reach runEnv when resolveStorageRoot threw"),
@@ -245,11 +245,14 @@ test("handleWorkerStateBrief: replay corrupted fixture surfaces as fault, not cr
   assert.match(result.payload.fault.reason, /fixture corrupted/);
 });
 
-test("handleWorkerStateBrief: hash compute failure surfaces as in-flow fault", () => {
+test("handleWorkerStateBrief: hash compute failure (record mode) surfaces as in-flow fault", () => {
+  // Live mode skips hashing entirely (regression-prevention for
+  // non-harness callers); the failure path only fires in record /
+  // replay mode where the hash is actually needed.
   const result = handleWorkerStateBrief(
     { state: "llm_trim", has_worker: true },
     "run-1",
-    { replayMode: "live" },
+    { replayMode: "record" },
     {
       resolveStorageRoot: () => "/tmp",
       runEnv: () => ({}),
@@ -285,22 +288,26 @@ test("handleWorkerStateBrief: record-mode stash failure surfaces as fault", () =
   assert.match(result.payload.fault.reason, /failed to stash pending brief/);
 });
 
-test("handleWorkerStateBrief: live-mode pauses with awaiting_worker even when stash fails", () => {
-  // Stash is best-effort in live mode; a write failure must NOT abort
-  // the run. The helper still returns kind:"pause" / awaiting_worker.
+test("handleWorkerStateBrief: live mode skips env+hash entirely and pauses", () => {
+  // The default live path must NOT touch the env loaders, hash, or
+  // stash. Pre-B7 a live --start didn't read the prompt template or
+  // load run-storage; introducing failure modes for callers who didn't
+  // opt into the harness would regress that. Stub all env-side
+  // dependencies to throw and assert the helper still returns a clean
+  // pause.
   const brief = { state: "llm_trim", has_worker: true };
   const result = handleWorkerStateBrief(
     brief,
     "run-1",
     { replayMode: "live" },
     {
-      resolveStorageRoot: () => "/tmp",
-      runEnv: () => ({}),
-      hashKeyForBrief: () => "e".repeat(64),
-      replayLookup: () => ({ hit: false }),
-      runFsmCommit: () => assert.fail("must not commit"),
-      stashPendingBrief: () => { throw new Error("disk full"); },
-      runDirPath: () => "/tmp/run",
+      resolveStorageRoot: () => assert.fail("live mode must not touch resolveStorageRoot"),
+      runEnv: () => assert.fail("live mode must not touch runEnv"),
+      hashKeyForBrief: () => assert.fail("live mode must not compute hashKey"),
+      replayLookup: () => assert.fail("live mode must not look up replays"),
+      runFsmCommit: () => assert.fail("live mode must not commit"),
+      stashPendingBrief: () => assert.fail("live mode must not stash"),
+      runDirPath: () => assert.fail("live mode must not touch runDirPath"),
       fixturesRoot: "/tmp/fixtures",
     },
   );

--- a/tests/unit/run-review.test.js
+++ b/tests/unit/run-review.test.js
@@ -319,6 +319,44 @@ test("handleWorkerStateBrief: record-mode stash failure surfaces as fault", () =
   assert.match(result.payload.fault.reason, /failed to stash pending brief/);
 });
 
+test("handleWorkerStateBrief: record mode happy path stashes brief and pauses", () => {
+  // The successful record-mode path: hash, runDirPath, stashPendingBrief
+  // all succeed; the helper must invoke stashPendingBrief with
+  // {state, hashKey} matching the brief and the computed hash, then
+  // return kind:"pause" / awaiting_worker so the runner emits the
+  // brief for the caller to dispatch.
+  const brief = { state: "llm_trim", has_worker: true };
+  const expectedHash = "1".repeat(64);
+  const stashCalls = [];
+  const result = handleWorkerStateBrief(
+    brief,
+    "run-1",
+    { replayMode: "record" },
+    {
+      resolveStorageRoot: () => "/tmp",
+      runEnv: () => ({}),
+      hashKeyForBrief: () => expectedHash,
+      replayLookup: () => assert.fail("must not look up replays in record mode"),
+      runFsmCommit: () => assert.fail("must not commit on the awaiting_worker path"),
+      stashPendingBrief: (dir, payload) => {
+        stashCalls.push({ dir, payload });
+      },
+      runDirPath: (runId, opts) => {
+        assert.equal(runId, "run-1");
+        assert.equal(opts.storageRoot, "/tmp");
+        return "/tmp/run-dir";
+      },
+      fixturesRoot: "/tmp/fixtures",
+    },
+  );
+  assert.equal(result.kind, "pause");
+  assert.equal(result.payload.status, "awaiting_worker");
+  assert.equal(result.payload.brief, brief);
+  assert.equal(stashCalls.length, 1);
+  assert.equal(stashCalls[0].dir, "/tmp/run-dir");
+  assert.deepEqual(stashCalls[0].payload, { state: "llm_trim", hashKey: expectedHash });
+});
+
 test("handleWorkerStateBrief: live mode skips env+hash entirely and pauses", () => {
   // The default live path must NOT touch the env loaders, hash, or
   // stash. Pre-B7 a live --start didn't read the prompt template or

--- a/tests/unit/worker-replay.test.js
+++ b/tests/unit/worker-replay.test.js
@@ -114,33 +114,29 @@ test("computeHashKey: same prompt body in CRLF and LF produces the same hash", a
   }
 });
 
-test("computeHashKey: rejects traversal / absolute promptTemplate (defense in depth)", () => {
+test("computeHashKey: rejects traversal / absolute / UNC promptTemplate (defense in depth)", () => {
   // Even though run-review wraps paths in repoRelativePromptPath first,
   // computeHashKey is exported and could be called from tooling that
-  // skips that sanitiser. Without this guard, `../../etc/passwd` would
-  // fold the resolved file into the hash.
+  // skips that sanitiser. Without these guards, `../../etc/passwd` (or
+  // a Windows-rooted / UNC path) would fold the resolved file into the
+  // hash. Cover POSIX absolute, Windows drive-letter, leading-backslash,
+  // and UNC variants in one parameterised pass.
   const root = mkdtempSync(join(tmpdir(), "replay-defense-"));
   try {
-    assert.throws(
-      () =>
-        computeHashKey({
-          state: "s",
-          promptTemplate: "../etc/passwd",
-          inputs: {},
-          repoRoot: root,
-        }),
-      /traversal segments or absolute roots/,
-    );
-    assert.throws(
-      () =>
-        computeHashKey({
-          state: "s",
-          promptTemplate: "/etc/passwd",
-          inputs: {},
-          repoRoot: root,
-        }),
-      /traversal segments or absolute roots/,
-    );
+    const bad = [
+      "../etc/passwd",
+      "/etc/passwd",
+      "C:\\Windows\\System32",
+      "\\Windows\\System32",
+      "\\\\server\\share\\file",
+    ];
+    for (const promptTemplate of bad) {
+      assert.throws(
+        () => computeHashKey({ state: "s", promptTemplate, inputs: {}, repoRoot: root }),
+        /traversal segments or absolute/,
+        `expected throw for promptTemplate=${JSON.stringify(promptTemplate)}`,
+      );
+    }
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tests/unit/worker-replay.test.js
+++ b/tests/unit/worker-replay.test.js
@@ -142,12 +142,16 @@ test("computeHashKey: rejects traversal / absolute / UNC promptTemplate (defense
   }
 });
 
-test("computeHashKey: rejects symlink that escapes repoRoot", async () => {
+test("computeHashKey: rejects symlink that escapes repoRoot", { skip: process.platform === "win32" ? "symlinkSync requires admin/Developer Mode on Windows" : false }, async () => {
   // Even a sanitised `fsm/workers/p.md` could target a symlink whose
   // realpath resolves outside the repo. Without the realpath boundary
   // check, a tampered prompt symlink would let an attacker fold
   // arbitrary file contents (e.g. /etc/passwd) into the hash and the
   // recorded fixture's content fingerprint.
+  //
+  // Windows: skip — fs.symlinkSync(file) requires admin / Developer
+  // Mode and most contributors will hit EPERM. The realpath boundary
+  // check itself is platform-agnostic; POSIX coverage is sufficient.
   const { mkdirSync, writeFileSync, symlinkSync, mkdtempSync } = await import("node:fs");
   const { tmpdir: td } = await import("node:os");
   const outsideDir = mkdtempSync(join(td(), "replay-outside-"));
@@ -156,7 +160,12 @@ test("computeHashKey: rejects symlink that escapes repoRoot", async () => {
   const repoRoot = makeTmpDir();
   try {
     mkdirSync(join(repoRoot, "fsm", "workers"), { recursive: true });
-    symlinkSync(outsideFile, join(repoRoot, "fsm", "workers", "leaky.md"));
+    try {
+      symlinkSync(outsideFile, join(repoRoot, "fsm", "workers", "leaky.md"));
+    } catch (err) {
+      if (err.code === "EPERM") return; // sandboxed runner without symlink permission
+      throw err;
+    }
     assert.throws(
       () =>
         computeHashKey({
@@ -239,17 +248,38 @@ test("recordOutputs + replayLookup: round-trip on disk", () => {
     });
     assert.ok(existsSync(written));
     const replayed = replayLookup(root, "llm_trim", hashKey);
-    assert.deepEqual(replayed, outputs);
+    assert.deepEqual(replayed, { hit: true, outputs });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-test("replayLookup: returns null on cache miss", () => {
+test("replayLookup: cache miss returns {hit: false}", () => {
   const root = makeTmpDir();
   try {
     const replayed = replayLookup(root, "llm_trim", "0".repeat(64));
-    assert.equal(replayed, null);
+    assert.deepEqual(replayed, { hit: false });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("replayLookup: legitimately-recorded null outputs distinguish from cache miss", async () => {
+  // A fixture written with `{ outputs: null }` must replay as
+  // {hit:true, outputs:null}, NOT collapse into a {hit:false} miss.
+  // Without the structured result shape, the caller can't tell these
+  // apart and replay-mode would silently retry a fixture that was
+  // legitimately recorded as null.
+  const root = makeTmpDir();
+  try {
+    const hashKey = "9".repeat(64);
+    const path = fixturePath(root, "llm_trim", hashKey);
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { dirname: dn } = await import("node:path");
+    mkdirSync(dn(path), { recursive: true });
+    writeFileSync(path, '{"outputs": null}\n', "utf8");
+    const replayed = replayLookup(root, "llm_trim", hashKey);
+    assert.deepEqual(replayed, { hit: true, outputs: null });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -331,7 +361,7 @@ test("end-to-end: record then replay produces structurally identical output", ()
     const first = replayLookup(root, "llm_trim", hashKey);
     const second = replayLookup(root, "llm_trim", hashKey);
     assert.deepEqual(first, second);
-    assert.deepEqual(first, fixture);
+    assert.deepEqual(first, { hit: true, outputs: fixture });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tests/unit/worker-replay.test.js
+++ b/tests/unit/worker-replay.test.js
@@ -164,6 +164,24 @@ test("replayLookup: returns null on cache miss", () => {
   }
 });
 
+test("replayLookup: throws on corrupted JSON (distinct from cache miss)", async () => {
+  // A corrupted fixture must not silently masquerade as a cache miss —
+  // replay-mode needs to fault loud on stale/bad fixtures so the user
+  // can re-record. Returning null here would silently regress replay.
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  const { dirname: dn } = await import("node:path");
+  const root = makeTmpDir();
+  try {
+    const hashKey = "d".repeat(64);
+    const path = fixturePath(root, "llm_trim", hashKey);
+    mkdirSync(dn(path), { recursive: true });
+    writeFileSync(path, "{not valid json", "utf8");
+    assert.throws(() => replayLookup(root, "llm_trim", hashKey), /invalid JSON/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("recordOutputs: file is pretty-printed JSON with trailing newline", () => {
   const root = makeTmpDir();
   try {

--- a/tests/unit/worker-replay.test.js
+++ b/tests/unit/worker-replay.test.js
@@ -82,6 +82,38 @@ test("computeHashKey: same inputs → same hash; any input change → different 
   assert.notEqual(a, diffInputs);
 });
 
+test("computeHashKey: same prompt body in CRLF and LF produces the same hash", async () => {
+  // Without CRLF normalization, a Windows checkout (core.autocrlf=true)
+  // would hash the same logical prompt to a different value than a
+  // Linux checkout, causing systematic cross-platform replay misses.
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  const { join: pj } = await import("node:path");
+  const lfRoot = makeTmpDir();
+  const crlfRoot = makeTmpDir();
+  try {
+    mkdirSync(pj(lfRoot, "fsm", "workers"), { recursive: true });
+    mkdirSync(pj(crlfRoot, "fsm", "workers"), { recursive: true });
+    writeFileSync(pj(lfRoot, "fsm", "workers", "p.md"), "line a\nline b\nline c\n");
+    writeFileSync(pj(crlfRoot, "fsm", "workers", "p.md"), "line a\r\nline b\r\nline c\r\n");
+    const lfHash = computeHashKey({
+      state: "s",
+      promptTemplate: "fsm/workers/p.md",
+      inputs: {},
+      repoRoot: lfRoot,
+    });
+    const crlfHash = computeHashKey({
+      state: "s",
+      promptTemplate: "fsm/workers/p.md",
+      inputs: {},
+      repoRoot: crlfRoot,
+    });
+    assert.equal(lfHash, crlfHash, "CRLF must hash equal to LF after normalization");
+  } finally {
+    rmSync(lfRoot, { recursive: true, force: true });
+    rmSync(crlfRoot, { recursive: true, force: true });
+  }
+});
+
 test("computeHashKey: throws when promptTemplate is unreadable under a given repoRoot", () => {
   // A bad promptTemplate path under a real repoRoot must surface — silent
   // empty-content fallback would mask a bug as a systematic replay miss.

--- a/tests/unit/worker-replay.test.js
+++ b/tests/unit/worker-replay.test.js
@@ -127,7 +127,7 @@ test("replayLookup: returns null on cache miss", () => {
   }
 });
 
-test("recordOutputs: file is canonical-JSON pretty-printed", () => {
+test("recordOutputs: file is pretty-printed JSON with trailing newline", () => {
   const root = makeTmpDir();
   try {
     const hashKey = "1".repeat(64);

--- a/tests/unit/worker-replay.test.js
+++ b/tests/unit/worker-replay.test.js
@@ -25,14 +25,23 @@ function makeTmpDir() {
   return mkdtempSync(join(tmpdir(), "worker-replay-test-"));
 }
 
-test("resolveReplayMode: defaults to live, accepts record/replay, ignores unknown", () => {
+test("resolveReplayMode: defaults to live, accepts record/replay (case-insensitive)", () => {
   assert.equal(resolveReplayMode({}), "live");
   assert.equal(resolveReplayMode({ "replay-mode": "live" }), "live");
   assert.equal(resolveReplayMode({ "replay-mode": "record" }), "record");
   assert.equal(resolveReplayMode({ "replay-mode": "replay" }), "replay");
   assert.equal(resolveReplayMode({ "replay-mode": "REPLAY" }), "replay");
-  assert.equal(resolveReplayMode({ "replay-mode": "garbage" }), "live");
   assert.equal(resolveReplayMode(null), "live");
+});
+
+test("resolveReplayMode: invokes onInvalid for bare flag and unknown values", () => {
+  const calls = [];
+  const onInvalid = (msg) => calls.push(msg);
+  assert.equal(resolveReplayMode({ "replay-mode": true }, { onInvalid }), "live");
+  assert.equal(resolveReplayMode({ "replay-mode": "garbage" }, { onInvalid }), "live");
+  assert.equal(calls.length, 2);
+  assert.match(calls[0], /bare flag/);
+  assert.match(calls[1], /must be one of/);
 });
 
 test("computeHashKey: same inputs → same hash; any input change → different hash", () => {
@@ -160,7 +169,7 @@ test("stash / read / clear pending-brief lifecycle", () => {
   }
 });
 
-test("end-to-end: record then replay produces byte-identical output", () => {
+test("end-to-end: record then replay produces structurally identical output", () => {
   const root = makeTmpDir();
   try {
     const hashKey = computeHashKey({
@@ -179,11 +188,38 @@ test("end-to-end: record then replay produces byte-identical output", () => {
     };
     recordOutputs(root, { state: "llm_trim", hashKey, outputs: fixture });
 
-    // Two replays — both must return byte-identical outputs.
+    // Two replays — both must return the same parsed value. (Replay
+    // returns parsed JSON; raw-byte equality of the on-disk fixture is
+    // exercised by the dedicated test below.)
     const first = replayLookup(root, "llm_trim", hashKey);
     const second = replayLookup(root, "llm_trim", hashKey);
     assert.deepEqual(first, second);
     assert.deepEqual(first, fixture);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("recordOutputs: re-recording the same outputs in different key order writes byte-identical files", () => {
+  // The determinism contract for the on-disk fixture is byte-level: a
+  // worker that emits the same logical outputs in a different key
+  // insertion order must produce the same bytes after canonicalization.
+  const root = makeTmpDir();
+  try {
+    const hashKey = "c".repeat(64);
+    const a = recordOutputs(root, {
+      state: "tree_descend",
+      hashKey,
+      outputs: { picked: [{ id: "a", path: "a.md", dimensions: ["correctness"] }], rejected: [] },
+    });
+    const bytesA = readFileSync(a);
+    const b = recordOutputs(root, {
+      state: "tree_descend",
+      hashKey,
+      outputs: { rejected: [], picked: [{ dimensions: ["correctness"], path: "a.md", id: "a" }] },
+    });
+    const bytesB = readFileSync(b);
+    assert.equal(bytesA.equals(bytesB), true, "canonicalized records must be byte-identical");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tests/unit/worker-replay.test.js
+++ b/tests/unit/worker-replay.test.js
@@ -82,6 +82,34 @@ test("computeHashKey: same inputs → same hash; any input change → different 
   assert.notEqual(a, diffInputs);
 });
 
+test("computeHashKey: throws when promptTemplate is unreadable under a given repoRoot", () => {
+  // A bad promptTemplate path under a real repoRoot must surface — silent
+  // empty-content fallback would mask a bug as a systematic replay miss.
+  const root = mkdtempSync(join(tmpdir(), "replay-prompt-"));
+  try {
+    assert.throws(
+      () =>
+        computeHashKey({
+          state: "llm_trim",
+          promptTemplate: "fsm/workers/does-not-exist.md",
+          inputs: {},
+          repoRoot: root,
+        }),
+      /prompt template not readable/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+  // Back-compat: without repoRoot, prompt-content hashing is opt-out;
+  // a missing file does NOT throw — only the path is hashed.
+  const hash = computeHashKey({
+    state: "llm_trim",
+    promptTemplate: "fsm/workers/does-not-exist.md",
+    inputs: {},
+  });
+  assert.match(hash, /^[a-f0-9]{64}$/);
+});
+
 test("computeHashKey: input key order doesn't affect the hash (canonical JSON)", () => {
   const a = computeHashKey({
     state: "s",

--- a/tests/unit/worker-replay.test.js
+++ b/tests/unit/worker-replay.test.js
@@ -142,6 +142,37 @@ test("computeHashKey: rejects traversal / absolute / UNC promptTemplate (defense
   }
 });
 
+test("computeHashKey: rejects symlink that escapes repoRoot", async () => {
+  // Even a sanitised `fsm/workers/p.md` could target a symlink whose
+  // realpath resolves outside the repo. Without the realpath boundary
+  // check, a tampered prompt symlink would let an attacker fold
+  // arbitrary file contents (e.g. /etc/passwd) into the hash and the
+  // recorded fixture's content fingerprint.
+  const { mkdirSync, writeFileSync, symlinkSync, mkdtempSync } = await import("node:fs");
+  const { tmpdir: td } = await import("node:os");
+  const outsideDir = mkdtempSync(join(td(), "replay-outside-"));
+  const outsideFile = join(outsideDir, "secret.md");
+  writeFileSync(outsideFile, "secret content");
+  const repoRoot = makeTmpDir();
+  try {
+    mkdirSync(join(repoRoot, "fsm", "workers"), { recursive: true });
+    symlinkSync(outsideFile, join(repoRoot, "fsm", "workers", "leaky.md"));
+    assert.throws(
+      () =>
+        computeHashKey({
+          state: "s",
+          promptTemplate: "fsm/workers/leaky.md",
+          inputs: {},
+          repoRoot,
+        }),
+      /symlink escapes repoRoot/,
+    );
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  }
+});
+
 test("computeHashKey: throws when promptTemplate is unreadable under a given repoRoot", () => {
   // A bad promptTemplate path under a real repoRoot must surface — silent
   // empty-content fallback would mask a bug as a systematic replay miss.

--- a/tests/unit/worker-replay.test.js
+++ b/tests/unit/worker-replay.test.js
@@ -114,6 +114,38 @@ test("computeHashKey: same prompt body in CRLF and LF produces the same hash", a
   }
 });
 
+test("computeHashKey: rejects traversal / absolute promptTemplate (defense in depth)", () => {
+  // Even though run-review wraps paths in repoRelativePromptPath first,
+  // computeHashKey is exported and could be called from tooling that
+  // skips that sanitiser. Without this guard, `../../etc/passwd` would
+  // fold the resolved file into the hash.
+  const root = mkdtempSync(join(tmpdir(), "replay-defense-"));
+  try {
+    assert.throws(
+      () =>
+        computeHashKey({
+          state: "s",
+          promptTemplate: "../etc/passwd",
+          inputs: {},
+          repoRoot: root,
+        }),
+      /traversal segments or absolute roots/,
+    );
+    assert.throws(
+      () =>
+        computeHashKey({
+          state: "s",
+          promptTemplate: "/etc/passwd",
+          inputs: {},
+          repoRoot: root,
+        }),
+      /traversal segments or absolute roots/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("computeHashKey: throws when promptTemplate is unreadable under a given repoRoot", () => {
   // A bad promptTemplate path under a real repoRoot must surface — silent
   // empty-content fallback would mask a bug as a systematic replay miss.

--- a/tests/unit/worker-replay.test.js
+++ b/tests/unit/worker-replay.test.js
@@ -1,0 +1,190 @@
+// Tests for the B7 worker-output replay harness. The harness is
+// pure-function over a fixtures directory + filesystem. Tests use a
+// temp directory per case so they don't pollute the real
+// tests/fixtures/worker-responses/ tree.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  computeHashKey,
+  fixturePath,
+  recordOutputs,
+  replayLookup,
+  resolveReplayMode,
+  stashPendingBrief,
+  readPendingBrief,
+  clearPendingBrief,
+} from "../../scripts/lib/worker-replay.mjs";
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), "worker-replay-test-"));
+}
+
+test("resolveReplayMode: defaults to live, accepts record/replay, ignores unknown", () => {
+  assert.equal(resolveReplayMode({}), "live");
+  assert.equal(resolveReplayMode({ "replay-mode": "live" }), "live");
+  assert.equal(resolveReplayMode({ "replay-mode": "record" }), "record");
+  assert.equal(resolveReplayMode({ "replay-mode": "replay" }), "replay");
+  assert.equal(resolveReplayMode({ "replay-mode": "REPLAY" }), "replay");
+  assert.equal(resolveReplayMode({ "replay-mode": "garbage" }), "live");
+  assert.equal(resolveReplayMode(null), "live");
+});
+
+test("computeHashKey: same inputs → same hash; any input change → different hash", () => {
+  const a = computeHashKey({
+    state: "llm_trim",
+    promptTemplate: "fsm/workers/trim-candidates.md",
+    inputs: { tier: "sensitive", cap: 30, stage_a_candidates: [{ id: "a" }] },
+  });
+  const b = computeHashKey({
+    state: "llm_trim",
+    promptTemplate: "fsm/workers/trim-candidates.md",
+    inputs: { tier: "sensitive", cap: 30, stage_a_candidates: [{ id: "a" }] },
+  });
+  assert.equal(a, b, "byte-identical inputs must produce identical hashes");
+
+  // Different state → different hash
+  const diffState = computeHashKey({
+    state: "tree_descend",
+    promptTemplate: "fsm/workers/trim-candidates.md",
+    inputs: { tier: "sensitive", cap: 30, stage_a_candidates: [{ id: "a" }] },
+  });
+  assert.notEqual(a, diffState);
+
+  // Different prompt template → different hash
+  const diffPrompt = computeHashKey({
+    state: "llm_trim",
+    promptTemplate: "fsm/workers/trim-candidates-v2.md",
+    inputs: { tier: "sensitive", cap: 30, stage_a_candidates: [{ id: "a" }] },
+  });
+  assert.notEqual(a, diffPrompt);
+
+  // Different inputs → different hash
+  const diffInputs = computeHashKey({
+    state: "llm_trim",
+    promptTemplate: "fsm/workers/trim-candidates.md",
+    inputs: { tier: "lite", cap: 8, stage_a_candidates: [{ id: "a" }] },
+  });
+  assert.notEqual(a, diffInputs);
+});
+
+test("computeHashKey: input key order doesn't affect the hash (canonical JSON)", () => {
+  const a = computeHashKey({
+    state: "s",
+    promptTemplate: "p",
+    inputs: { alpha: 1, beta: 2, gamma: { x: 1, y: 2 } },
+  });
+  const b = computeHashKey({
+    state: "s",
+    promptTemplate: "p",
+    inputs: { gamma: { y: 2, x: 1 }, beta: 2, alpha: 1 },
+  });
+  assert.equal(a, b);
+});
+
+test("fixturePath: rejects bad state / hashKey", () => {
+  assert.throws(() => fixturePath("/tmp", "", "a".repeat(64)));
+  assert.throws(() => fixturePath("/tmp", "x", "not-a-hex-sha256"));
+  assert.throws(() => fixturePath("/tmp", "x", "abcdef"));
+});
+
+test("fixturePath: produces <root>/<state>/<hash>.json", () => {
+  const p = fixturePath("/tmp/fixtures", "llm_trim", "a".repeat(64));
+  assert.equal(p, join("/tmp/fixtures", "llm_trim", `${"a".repeat(64)}.json`));
+});
+
+test("recordOutputs + replayLookup: round-trip on disk", () => {
+  const root = makeTmpDir();
+  try {
+    const hashKey = "f".repeat(64);
+    const outputs = { picked_leaves: [{ id: "lang-typescript" }] };
+    const written = recordOutputs(root, {
+      state: "llm_trim",
+      hashKey,
+      outputs,
+      meta: { recorded_at: "2026-04-27T00:00:00Z" },
+    });
+    assert.ok(existsSync(written));
+    const replayed = replayLookup(root, "llm_trim", hashKey);
+    assert.deepEqual(replayed, outputs);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("replayLookup: returns null on cache miss", () => {
+  const root = makeTmpDir();
+  try {
+    const replayed = replayLookup(root, "llm_trim", "0".repeat(64));
+    assert.equal(replayed, null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("recordOutputs: file is canonical-JSON pretty-printed", () => {
+  const root = makeTmpDir();
+  try {
+    const hashKey = "1".repeat(64);
+    const path = recordOutputs(root, {
+      state: "tree_descend",
+      hashKey,
+      outputs: { stage_a_candidates: [], descent_path: [] },
+    });
+    const body = readFileSync(path, "utf8");
+    assert.match(body, /^\{\n  "outputs": \{/, "fixture should be pretty-printed JSON");
+    assert.ok(body.endsWith("\n"), "fixture should end with newline");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("stash / read / clear pending-brief lifecycle", () => {
+  const dir = makeTmpDir();
+  try {
+    assert.equal(readPendingBrief(dir), null);
+    stashPendingBrief(dir, { state: "llm_trim", hashKey: "a".repeat(64) });
+    const read = readPendingBrief(dir);
+    assert.equal(read.state, "llm_trim");
+    assert.equal(read.hashKey, "a".repeat(64));
+    clearPendingBrief(dir);
+    // After clear the file is empty (not removed); reading should yield null.
+    assert.equal(readPendingBrief(dir), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("end-to-end: record then replay produces byte-identical output", () => {
+  const root = makeTmpDir();
+  try {
+    const hashKey = computeHashKey({
+      state: "llm_trim",
+      promptTemplate: "fsm/workers/trim-candidates.md",
+      inputs: {
+        tier: "sensitive",
+        cap: 30,
+        stage_a_candidates: [{ id: "lang-typescript", path: "lang-typescript.md", activation_match: ["file_globs"] }],
+      },
+    });
+    const fixture = {
+      picked_leaves: [{ id: "lang-typescript", path: "lang-typescript.md", justification: "ok", dimensions: ["correctness"] }],
+      rejected_leaves: [],
+      coverage_rescues: [],
+    };
+    recordOutputs(root, { state: "llm_trim", hashKey, outputs: fixture });
+
+    // Two replays — both must return byte-identical outputs.
+    const first = replayLookup(root, "llm_trim", hashKey);
+    const second = replayLookup(root, "llm_trim", hashKey);
+    assert.deepEqual(first, second);
+    assert.deepEqual(first, fixture);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Sprint B B7 — adds --replay-mode={live|record|replay} to the runner. Replay mode auto-commits recorded fixture outputs without emitting awaiting_worker; record mode persists every worker output keyed by sha256(state | prompt-template | canonical-json(inputs)). Tests cover all three modes + hash determinism + round-trip. Closes #12