### PR TITLE
chore(security): pin actions, pin FSM dep, add timeout, SBOM, prepublishOnly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write
@@ -28,9 +29,9 @@ jobs:
           echo "::error::Re-dispatch against an existing v<version> tag, or push a new one via the release flow."
           exit 1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -57,6 +58,16 @@ jobs:
             echo "::error::Investigate the merge commit; this should not happen under the PR-based flow."
             exit 1
           fi
+
+      - name: Generate SBOM
+        run: npx --yes @cyclonedx/cyclonedx-npm --output-file sbom.cdx.json
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom
+          path: sbom.cdx.json
+          if-no-files-found: error
 
       - name: Publish
         run: npm publish --access public --provenance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,13 @@ The FSM design substrate, CLI reference, state-YAML schema, worker contract, and
 - [`worker-contract.md`](https://github.com/ctxr-dev/fsm/blob/main/docs/worker-contract.md)
 - [`storage-layout.md`](https://github.com/ctxr-dev/fsm/blob/main/docs/storage-layout.md)
 
-`package.json` references `@ctxr/fsm` via `git+https://github.com/ctxr-dev/fsm.git#main`, so `npm install` always resolves from the latest `main` of the FSM package — no sibling checkout required, no manual SHA bump needed. Note: npm caches git deps by URL, so to force a refresh after FSM `main` advances, run `npm install --force` (or explicitly reinstall with `npm install --save "@ctxr/fsm@git+https://github.com/ctxr-dev/fsm.git#main"`, or delete `node_modules/@ctxr/fsm` and reinstall).
+`package.json` references `@ctxr/fsm` via `git+https://github.com/ctxr-dev/fsm.git#<commit-sha>` — pinned to a full 40-character commit SHA so `npm ci` resolves the same engine bytes on every run, and the `npm publish --provenance` attestation has a stable subject closure (no silent floats from `main`). To pick up new FSM commits, bump the SHA explicitly:
+
+```bash
+npm install --save "@ctxr/fsm@git+https://github.com/ctxr-dev/fsm.git#<new-sha>"
+```
+
+(or fetch the latest with `gh api repos/ctxr-dev/fsm/commits/main --jq '.sha'` and reinstall against it).
 
 **For local engine hacking** against a sibling checkout at `../fsm`, override the dep temporarily:
 
@@ -86,10 +92,11 @@ npm install --save file:../fsm   # writes "@ctxr/fsm": "file:../fsm" into packag
 # ... iterate locally; changes in ../fsm are picked up immediately
 ```
 
-Revert to the upstream-resolvable form before committing:
+Revert to a pinned upstream form before committing:
 
 ```bash
-npm install --save "@ctxr/fsm@git+https://github.com/ctxr-dev/fsm.git#main"
+SHA=$(gh api repos/ctxr-dev/fsm/commits/main --jq '.sha')
+npm install --save "@ctxr/fsm@git+https://github.com/ctxr-dev/fsm.git#$SHA"
 ```
 
 `.fsmrc.json` at the repo root tells the FSM CLIs where the FSM YAML and storage root live:
@@ -130,7 +137,7 @@ npm run lint           # markdown lint
 npm run lint:fix       # auto-fix markdown issues
 ```
 
-The pre-commit hook runs `validate:src + lint`.
+The pre-commit hook runs `validate:fsm + lint`. (Maintainers authoring new reviewers should additionally run `npm run validate:src` locally against their `reviewers.src/` checkout before opening a PR — the source layer is gitignored, so the hook can't enforce it for everyone.)
 
 #### What the Source Validators Check
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,15 @@
       "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "@ctxr/fsm": "git+https://github.com/ctxr-dev/fsm.git#721d79e"
+        "@ctxr/fsm": "git+https://github.com/ctxr-dev/fsm.git#721d79e9ba93248c0e9ee0b94b328c15ac80bff7"
       },
       "devDependencies": {
         "gray-matter": "^4.0.3",
         "husky": "^9.1.0",
         "markdownlint-cli2": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@ctxr/fsm": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "type": "skill",
     "target": "folder"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "test": "node --test tests/unit/*.test.js tests/integration/*.test.js",
     "test:unit": "node --test tests/unit/*.test.js",
@@ -49,10 +52,11 @@
     "review": "node scripts/run-review.mjs",
     "lint": "markdownlint-cli2 '**/*.md' '#node_modules'",
     "lint:fix": "markdownlint-cli2 --fix '**/*.md' '#node_modules'",
-    "prepare": "husky"
+    "prepare": "husky",
+    "prepublishOnly": "npm run validate:fsm && npm run lint && npm test"
   },
   "dependencies": {
-    "@ctxr/fsm": "git+https://github.com/ctxr-dev/fsm.git#main"
+    "@ctxr/fsm": "git+https://github.com/ctxr-dev/fsm.git#721d79e9ba93248c0e9ee0b94b328c15ac80bff7"
   },
   "devDependencies": {
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary

Addresses the findings from the post-merge code review on `da3aa3a` (CI/release simplification commit). Four Important + four Minor reviewer findings folded into a single hardening PR.

## Findings addressed

| Severity | File | Finding | Fix |
|---|---|---|---|
| Important | `.github/workflows/publish.yml:31` | `actions/checkout@v4` not SHA-pinned (job holds `NPM_TOKEN` + `id-token: write`) | Pinned to `34e114876b...` (`v4.3.1`) |
| Important | `.github/workflows/publish.yml:33` | `actions/setup-node@v4` not SHA-pinned | Pinned to `49933ea5...` (`v4.4.0`) |
| Important | `package.json:55` | `@ctxr/fsm` resolves from mutable `#main` branch | Pinned to commit SHA `721d79e9...` |
| Important | `CONTRIBUTING.md:133` | Stale prose still said pre-commit hook runs `validate:src + lint` | Updated to `validate:fsm + lint` and clarified maintainer-only `validate:src` |
| Minor | `.github/workflows/publish.yml:11` | No `timeout-minutes` (360-min default) | Added `timeout-minutes: 15` |
| Minor | `.github/workflows/publish.yml:62` | No SBOM alongside `--provenance` | Added CycloneDX SBOM generation + workflow artifact upload (`actions/upload-artifact@ea165f8d...` v4.6.2) |
| Minor | `package.json` | No `prepublishOnly` gate for manual `npm publish` | Added `prepublishOnly: validate:fsm + lint + test` |
| Minor | `package.json` | No `engines` field on Node-version-sensitive package | Added `engines.node: ">=20"` |

## Local verification

- `npm install` clean against the pinned FSM SHA, `package-lock.json` updated.
- `npm run validate:fsm` → 0 errors, 14 states.
- `npm run lint` → 0 errors over 561 files.
- `npm test` → 178/178 pass.
- `npx @cyclonedx/cyclonedx-npm` dry-run → 115KB SBOM produced cleanly.

## Notes

- The FSM dep pin breaks the previous "always resolves the latest `main`" ergonomic; CONTRIBUTING.md now documents the explicit-bump flow (`gh api repos/ctxr-dev/fsm/commits/main --jq '.sha'`). If you'd rather keep the floating-`main` ergonomic and accept the supply-chain trade-off, revert the `package.json` + `CONTRIBUTING.md` parts of this PR.
- Action versions are pinned to the latest `v4.x` patch tags, not bumped to `v6` — major-version upgrades are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)