### PR TITLE
fix(skill): tighten verbatim-surface, fault-stop, prompt body in brief (PR A of #70)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,21 +26,21 @@ The brief has this shape (only the fields you need):
   "worker": {
     "role":             <worker name, e.g. "project-scanner">,
     "prompt_template":  <path under fsm/, e.g. "workers/project-scanner.md">,
+    "prompt_body":      <bytes of the worker prompt file, shipped with the brief>,
     "response_schema":  <JSON Schema the worker output is validated against>
   }
 }
 ```
 
-1. Read **only** `fsm/<brief.worker.prompt_template>` (the worker prompt file). Do not read anything else (not the wiki, not the design doc, not the gate predicates, not other workers).
-2. Build the worker prompt by concatenating the file body with the `brief.inputs` values the worker needs.
-3. Dispatch via the `Agent` tool. The worker must return a single JSON object satisfying `brief.worker.response_schema`.
-4. Write the response to a temp file (`/tmp/worker-out-<run_id>.json` is fine), then call:
+1. Build the worker prompt by concatenating `brief.worker.prompt_body` (already provided) with the `brief.inputs` values the worker needs. **Do not** Read the file at `brief.worker.prompt_template` — the runner already shipped its bytes in `prompt_body`. **Do not** read anything else (not the wiki, not the design doc, not the gate predicates, not other workers).
+2. Dispatch via the `Agent` tool. The worker must return a single JSON object satisfying `brief.worker.response_schema`.
+3. Write the response to a temp file (`/tmp/worker-out-<run_id>.json` is fine), then call:
 
    ```
    node scripts/run-review.mjs --continue --run-id <run_id> --outputs-file <path>
    ```
 
-5. Loop on the next stdout line.
+4. Loop on the next stdout line.
 
 ### On `{"status": "terminal", "run_id": "<id>", "verdict": "...", "run_dir_path": "<path>"}`
 
@@ -53,11 +53,11 @@ The brief has this shape (only the fields you need):
    Exit 0 means OK. Exit non-zero means stop and surface the error.
 
 2. Read `<run_dir_path>/report.md`.
-3. **Your final response is the contents of `report.md` followed by a literal trailing line `Manifest: <run_dir_path>/manifest.json`.** Do not paraphrase or summarise the report; surface it verbatim.
+3. **Your final response is the literal bytes of `<run_dir_path>/report.md`, followed by exactly one trailing line: `Manifest: <run_dir_path>/manifest.json`. Nothing more, nothing less.** Do not edit, paraphrase, summarise, reformat, transpose columns, drop rows, or "polish" the report. If a column or table seems redundant, that is not your call. The runner produced the report in this exact shape on purpose; your job is to surface it byte-for-byte. If `report.md` is too long for your context, link to its path instead — never edit it.
 
 ### On `{"status": "fault" | "error", ...}`
 
-Surface the message to the user. Do not retry silently. Do not fall back to a manual review.
+**Any** fault or error output is a stop signal — even if other output (such as a `report.md` on disk, or a Manifest line) appears valid alongside it. Surface the fault payload to the user verbatim. Do not retry silently. Do not fall back to a manual review. Do not editorialise the fault as "cosmetic" or "known": that judgement is the user's, not yours.
 
 ---
 

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -156,6 +156,43 @@ export function repoRelativePromptPath(briefPath) {
   return `${FSM_YAML_DIR_REL}/${norm}`;
 }
 
+// Bake the worker prompt body into the brief so the orchestrator (the LLM
+// driving --start/--continue) can use brief.worker.prompt_body directly
+// instead of having to Read the file at brief.worker.prompt_template. SKILL.md
+// instructs the orchestrator NOT to read the file separately. The runner
+// reads it once here, on the way out, and ships its bytes in the brief.
+//
+// Failures to read are surfaced as a missing prompt_body (not a fault):
+// the brief still flows, the orchestrator still has the prompt_template
+// path it can fall back to, and any hashing / fixture-record code that
+// ALREADY needs the file body will surface its own errors at that point.
+// We do NOT want a transient ENOENT on prompt-body enrichment to fault
+// out a run that would otherwise advance fine.
+export function enrichBriefWithPromptBody(brief) {
+  const promptTemplate = brief?.worker?.prompt_template;
+  if (!promptTemplate || typeof promptTemplate !== "string") return brief;
+  let bodyPath;
+  try {
+    bodyPath = resolve(REPO_ROOT, repoRelativePromptPath(promptTemplate));
+  } catch {
+    return brief;
+  }
+  let body;
+  try {
+    body = readFileSync(bodyPath, "utf8");
+  } catch {
+    return brief;
+  }
+  // Return a new object with the enriched worker; do not mutate input.
+  return {
+    ...brief,
+    worker: {
+      ...brief.worker,
+      prompt_body: body,
+    },
+  };
+}
+
 function hashKeyForBrief(brief, env) {
   const briefPath = brief?.prompt_template ?? brief?.worker?.prompt_template ?? "";
   return computeHashKey({
@@ -450,7 +487,18 @@ export function parseFsmCliResult(result, label) {
     };
   }
   try {
-    return { ok: true, payload: JSON.parse(result.stdout) };
+    const payload = JSON.parse(result.stdout);
+    // Enrich every fsm-* payload that carries a worker brief with the
+    // prompt body so the orchestrator (the LLM driving the --start /
+    // --continue loop) does not need to Read the prompt-template file.
+    // Two shapes can appear here:
+    //   1. fsm-next --new-run / --resume: payload IS the brief (with
+    //      state, worker, inputs, ...).
+    //   2. fsm-commit advance: payload is { advanced_from, ...brief }.
+    // Both have the same `worker` shape when a worker state is reached.
+    // Terminal payloads (status: "terminal") have no `worker`; the
+    // helper short-circuits on missing prompt_template.
+    return { ok: true, payload: enrichBriefWithPromptBody(payload) };
   } catch (err) {
     return {
       ok: false,
@@ -683,6 +731,33 @@ async function loop(brief, runId, { replayMode = "live", sessionId } = {}) {
         verdict: current.verdict,
         run_dir_path: current.run_dir_path,
       };
+    }
+    // Terminal-state brief detection. The FSM YAML declares `terminal` as a
+    // no-op end state (no worker, no transitions). When fsm-commit advances
+    // INTO terminal it emits a brief with state="terminal" and no
+    // `status: "terminal"` envelope (that envelope is only emitted when
+    // fsm-commit is called WITH terminal as the committed state). Without
+    // this branch the loop falls into dispatchInlineState, fails to find
+    // an `inline-states/terminal.mjs` handler, and surfaces a spurious
+    // fault AFTER the canonical report+Manifest were already written.
+    // Calling fsm-commit one more time with empty outputs lets fsm-commit
+    // mark the run completed and release the lock cleanly, then emit the
+    // proper { status: "terminal", verdict, run_dir_path } payload.
+    if (current.state === "terminal" && !current.has_worker) {
+      const finalCommit = runFsmCommit({ runId, outputs: {}, sessionId });
+      if (!finalCommit.ok) {
+        return {
+          status: "fault",
+          run_id: runId,
+          fault: {
+            state: "terminal",
+            reason: `fsm-commit on terminal state failed: ${finalCommit.error}`,
+            details: finalCommit.raw,
+          },
+        };
+      }
+      current = finalCommit.payload;
+      continue;
     }
     if (current.has_worker) {
       const result = handleWorkerStateBrief(current, runId, { replayMode });

--- a/tests/integration/end-to-end-runner.test.js
+++ b/tests/integration/end-to-end-runner.test.js
@@ -73,6 +73,25 @@ test("runner --start: emits awaiting_worker JSON with project-scanner brief and 
   assert.equal(firstLine.brief.worker?.role, "project-scanner");
   assert.equal(firstLine.brief.worker?.prompt_template, "workers/project-scanner.md");
 
+  // PR A regression for divergence #7: the runner must ship the worker
+  // prompt body inside brief.worker.prompt_body so the orchestrator does
+  // not need to Read the file separately. Assert the bytes are present
+  // and match the actual on-disk file.
+  assert.ok(
+    typeof firstLine.brief.worker?.prompt_body === "string"
+      && firstLine.brief.worker.prompt_body.length > 0,
+    "brief.worker.prompt_body must be a non-empty string",
+  );
+  const promptOnDisk = readFileSync(
+    `${REPO_ROOT}/fsm/workers/project-scanner.md`,
+    "utf8",
+  );
+  assert.equal(
+    firstLine.brief.worker.prompt_body,
+    promptOnDisk,
+    "brief.worker.prompt_body must equal fsm/workers/project-scanner.md byte-for-byte",
+  );
+
   // The FSM engine seeds the manifest at run-init with base_sha / head_sha
   // taken from --base / --head. Confirm assert-fresh-run.mjs accepts it.
   const settings = resolveSettings({ fsmName: "code-reviewer" }, REPO_ROOT);
@@ -194,6 +213,22 @@ test("runner --start → --continue: chains across subprocesses without lock_not
       cont.stderr,
       /Manifest: .*manifest\.json/,
       `--continue did not emit the Manifest trailer; stderr=${cont.stderr}`,
+    );
+
+    // PR A regression for divergence #2: the runner must NOT emit a
+    // trailing fault payload after the canonical report+Manifest. The
+    // pre-fix runner would dispatch the no-op `terminal` state as an
+    // inline state, fail to find an `inline-states/terminal.mjs` handler,
+    // and emit a spurious {"status":"fault","fault":{"state":"terminal",
+    // "reason":"Inline-state handler not found..."}} AFTER the report.
+    // The fix in loop() detects state==="terminal" and calls fsm-commit
+    // one more time with empty outputs to get the proper terminal payload.
+    assert.equal(
+      /"state"\s*:\s*"terminal".*Inline-state handler not found/.test(
+        cont.stdout + cont.stderr,
+      ),
+      false,
+      `--continue trailed the no-op terminal-state fault; PR A regression. stdout=${cont.stdout} stderr=${cont.stderr}`,
     );
 
     // Read the canonical report.json from the run dir directly (avoids


### PR DESCRIPTION
First of four PRs landing the audit fixes from #70. Covers divergences #1, #2, #7.

## Summary

- **#1 — Final response paraphrased.** SKILL.md now reads "the literal bytes of `report.md`, plus exactly one trailing line: `Manifest: <path>`. Nothing more, nothing less." Names the cognitive bias (polishing for the reader) and explicitly forbids editing/transposing/dropping rows.
- **#2 — Post-terminal fault not surfaced.** SKILL.md fault-stop wording tightened: "ANY fault or error output is a stop signal — even if other output appears valid alongside it. Do not editorialise the fault as 'cosmetic' or 'known'." AND the spurious post-terminal fault that triggered the divergence is fixed in `loop()`: when the FSM advances into the no-op `terminal` state, the runner now calls `fsm-commit` once more with empty outputs so `fsm-commit` emits the proper `{"status":"terminal"}` envelope. No more trailing `Inline-state handler not found: terminal.mjs` fault after `report.md` is written.
- **#7 — Prompt body in brief.** New exported `enrichBriefWithPromptBody(brief)` reads `brief.worker.prompt_template` and embeds its bytes as `brief.worker.prompt_body`. Wired into `parseFsmCliResult` so every fsm-* response carrying a worker brief gets enriched. SKILL.md instructs the orchestrator to use `prompt_body` directly and explicitly forbids the separate Read.

## Test plan

- [x] `npm run validate:fsm` — 0 errors, 14 states
- [x] `npm run lint` — 0 errors over 562 files
- [x] `npm test` — 188/188 (existing suite + 2 new assertions in the e2e test)
- [x] New assertion: `brief.worker.prompt_body` equals `fsm/workers/project-scanner.md` byte-for-byte
- [x] New assertion: `--continue` chain output contains no trailing `terminal` + `Inline-state handler not found` fault
- [ ] CI green

## Files

```
modified:   SKILL.md                                    # verbatim-surface and fault-stop wording
modified:   scripts/run-review.mjs                      # terminal-state loop fix + enrichBriefWithPromptBody helper
modified:   tests/integration/end-to-end-runner.test.js # two new regression assertions
```

Refs #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)