### PR TITLE
feat(fsm): activate_leaves inline state (B6 reframe; PR C of #70)

### DIFF
--- a/fsm/code-reviewer.fsm.yaml
+++ b/fsm/code-reviewer.fsm.yaml
@@ -92,15 +92,41 @@ fsm:
           when:
             kind: deterministic
             expression: "tier == 'trivial' AND len(risk_signals) == 0 AND NOT scope_overrides_present"
+        - to: activate_leaves
+          when: always
+
+    # ─── Step 2.5 (B6 reframe; #70 divergence #4) ───────────────
+    - id: activate_leaves
+      purpose: "Run the activation gate over every wiki leaf deterministically; produce activated_leaves[] for the tree-descender to consume as its candidate set."
+      preconditions:
+        - "project_profile exists in run state"
+        - "changed_paths exists in run state"
+      # Inline state: no worker. The FSM Orchestrator imports
+      # scripts/lib/activation-gate.mjs's evaluateActivation() and runs
+      # it over every leaf under reviewers.wiki/, producing
+      # activated_leaves[] that the next state (tree_descend) consumes
+      # as a precomputed candidate set. This removes the "did the LLM
+      # actually invoke the activation gate?" trust gap that the audit
+      # in #70 surfaced as divergence #4.
+      outputs:
+        - activated_leaves
+      post_validations:
+        - "activated_leaves is an array"
+      transitions:
+        - to: stage_a_empty
+          when:
+            kind: deterministic
+            expression: "len(activated_leaves) == 0"
         - to: tree_descend
           when: always
 
     # ─── Step 3 ─────────────────────────────────────────────────
     - id: tree_descend
-      purpose: "Walk reviewers.wiki by focus + activation gate; gather candidate leaves."
+      purpose: "Filter activated_leaves[] by parent subcategory focus (semantic LLM judgement); emit stage_a_candidates as the trim worker's input set."
       preconditions:
         - "project_profile exists in run state"
         - "tier exists in run state"
+        - "activated_leaves exists in run state"
       worker:
         role: tree-descender
         prompt_template: workers/tree-descender.md
@@ -108,6 +134,7 @@ fsm:
           - project_profile
           - changed_paths
           - tier
+          - activated_leaves
         response_schema:
           type: object
           required: [stage_a_candidates, descent_path]

--- a/fsm/workers/tree-descender.md
+++ b/fsm/workers/tree-descender.md
@@ -1,26 +1,29 @@
 # Worker: tree-descender
 
-You are the **tree-descender** worker. Your job is to walk `reviewers.wiki/` and produce a candidate set of specialist leaves whose `focus` and `activation:` block plausibly match the diff.
+You are the **tree-descender** worker. Your job: take the precomputed `activated_leaves[]` from the runner-side activation gate and filter it down to a smaller `stage_a_candidates[]` set by walking the wiki's subcategory `focus` strings semantically. The boolean activation logic ran in the runner (see PR C of #70 — divergence #4); you must NOT re-evaluate it.
 
 ## Inputs
 
 - `project_profile` — languages, frameworks, monorepo, infra (from Step 1).
 - `changed_paths` — list of changed file paths in the diff.
 - `tier` — risk tier (`trivial` / `lite` / `full` / `sensitive`).
+- `activated_leaves` — Array<{ id, path, activation_match: string[] }> already produced by the FSM's `activate_leaves` inline state. The activation gate (`scripts/lib/activation-gate.mjs`) has already evaluated every leaf's `activation:` block deterministically. **You do not run the gate; you consume its output.**
 
 ## Task
 
-Walk the wiki tree and emit Stage-A candidates. (Step 3 design rationale lives at `docs/code-reviewer-design.md`; you don't need to read it — this prompt is self-contained.)
+Filter `activated_leaves[]` by parent subcategory focus to drop branches whose focus is clearly orthogonal to this diff:
 
 1. **Read** `reviewers.wiki/index.md`. Its `entries:` block lists the top-level subcategories with `id`, `file`, `focus`, and (sometimes) `tags`.
-2. **Top-level descent** — for each top-level entry, decide whether to descend by matching the `focus` string semantically against `project_profile` AND the diff content (file types, dependency mentions, code shape signals).
+2. **Top-level descent** — for each top-level entry, decide whether its subtree is relevant by matching the `focus` string semantically against `project_profile` AND the diff content (file types, dependency mentions, code shape signals).
    - Drop branches whose focus is clearly orthogonal.
    - Keep branches that are partially or wholly relevant.
    - Keep cross-cutting branches (security, correctness, tests, docs, performance) when ANY part of the diff plausibly triggers their concerns.
-3. **Sub-category descent** — for each retained branch, read its `index.md`. If `entries[].type == "index"`, descend further; otherwise treat them as leaves.
-4. **Leaf activation gate** — `activation:` block evaluation (`file_globs`, `keyword_matches`, `structural_signals`, `escalation_from`) is deterministic. Invoke the helper [`scripts/lib/activation-gate.mjs`](../../scripts/lib/activation-gate.mjs) directly from this worker (import its `evaluateActivation({leaves, changed_paths, project_profile, diff_text})` and feed it the leaves you've descended to). Use the returned `activated[]` set as the candidate list and carry through the `descent_signals` map verbatim into each candidate's `activation_match[]`. The worker only does semantic descent (focus matching) by hand; the boolean activation logic is not LLM judgement. Lifting the activation gate up into the runner so the worker just consumes a precomputed `activated_leaves[]` from env lands under the B6 reframe.
+3. **Sub-category descent** — for retained branches, read each `index.md`. If `entries[].type == "index"`, descend further; otherwise the entries point at leaves.
+4. **Emit `stage_a_candidates`** — for each retained subcategory, output every entry from `activated_leaves[]` whose `path` falls under that subcategory's directory. Carry through each leaf's `id`, `path`, and `activation_match` **verbatim** from `activated_leaves[]`. Do not re-evaluate; do not invent new `activation_match` values.
 
-   For leaves with NO `activation:` block, mark them iff their parent subcategory was retained AND their `focus` is itself a clear match against the diff. Emit `activation_match: ["focus_only"]` for these leaves — the FSM schema accepts `focus_only` as a first-class signal alongside `file_globs`, `keyword_matches`, `structural_signals`, and `escalation_from`, and it requires the array to be non-empty.
+If a leaf is in `activated_leaves[]` but its parent subcategory was dropped during semantic descent, omit it from `stage_a_candidates[]` (the focus-orthogonality filter).
+
+If `activated_leaves[]` is empty, the FSM short-circuits to `stage_a_empty` BEFORE this worker is dispatched. You will only ever receive a non-empty set.
 
 ## Output (JSON, schema-validated)
 
@@ -43,20 +46,22 @@ Walk the wiki tree and emit Stage-A candidates. (Step 3 design rationale lives a
 
 Fields:
 
-- `stage_a_candidates[].id` — must match the leaf's `id:` frontmatter field exactly (kebab-case).
-- `stage_a_candidates[].path` — relative path under `reviewers.wiki/` to the leaf file.
-- `stage_a_candidates[].activation_match` — array listing which signals fired (subset of `[file_globs, keyword_matches, structural_signals, escalation_from]`); MUST be non-empty.
+- `stage_a_candidates[].id` — kebab-case leaf id, copied verbatim from the corresponding entry in `activated_leaves[]`.
+- `stage_a_candidates[].path` — copied verbatim from `activated_leaves[]`. The runner produced this; do not transform.
+- `stage_a_candidates[].activation_match` — copied verbatim from `activated_leaves[]`. **Do not re-evaluate.** The set of allowed values is `{file_globs, keyword_matches, structural_signals, escalation_from, focus_only}` and the array is non-empty by construction (the runner only includes leaves with at least one fired signal).
 - `descent_path` — the top-level subcategory ids you descended into (for audit).
 
 ## Constraints
 
 - Use semantic judgement on `focus` strings — do NOT keyword-grep them.
-- Allowed reads: the root `reviewers.wiki/index.md`, every retained subcategory `index.md`, and **leaf frontmatter only** (the YAML block at the top of a leaf `.md`) when needed to evaluate the `activation:` block.
-- Do NOT read leaf `.md` body content. The parent index's focus + the leaf's frontmatter is the only routing signal you need; the body is reserved for the specialist worker that gets dispatched later.
+- Allowed reads: the root `reviewers.wiki/index.md` and every retained subcategory `index.md`.
+- Do NOT read leaf `.md` files (frontmatter or body) — `activated_leaves[]` already gives you everything you need to assemble the output.
+- **Do NOT call `evaluateActivation()` or re-implement activation logic.** The runner already did that. If you find yourself reading a leaf's `activation:` block, stop — that signals you've drifted from the contract.
 - Return ONLY the JSON object.
 
 ## Validation will reject
 
 - `stage_a_candidates[].id` not matching `^[a-z][a-z0-9-]*$`.
-- `activation_match` empty or containing values outside `{file_globs, keyword_matches, structural_signals, escalation_from}`.
+- `activation_match` empty or containing values outside `{file_globs, keyword_matches, structural_signals, escalation_from, focus_only}`.
+- A `stage_a_candidates[]` entry whose `id` does NOT appear in `activated_leaves[]`. (Trim worker's referential integrity carries this through downstream — fabricated leaves are a hard fail.)
 - Missing required fields per the FSM YAML's `response_schema`.

--- a/scripts/inline-states/activate-leaves.mjs
+++ b/scripts/inline-states/activate-leaves.mjs
@@ -1,0 +1,171 @@
+// activate-leaves.mjs — deterministic activation-gate evaluation as an
+// FSM inline state. Implements PR C of the audit in #70 (B6 reframe of
+// the tree_descend worker).
+//
+// Before this state existed, the activation-gate was evaluated INSIDE the
+// tree-descender worker (sub-agent), per the prompt at
+// fsm/workers/tree-descender.md. The orchestrator could not verify the
+// gate actually ran — the activation_match values in the worker's output
+// could be LLM-eyeballed instead of computed. This handler runs the gate
+// in the runner's process where activation evaluation is deterministic
+// and visible in the FSM trace.
+//
+// Inputs (from env):
+//   - project_profile : Step 1 output
+//   - changed_paths   : Step 1 output
+//   - args            : the orchestrator's arg bag (for base/head SHAs)
+//
+// Outputs:
+//   - activated_leaves : Array<{ id, path, activation_match: string[] }>
+//                        where activation_match ⊆ { file_globs, keyword_matches,
+//                        structural_signals, escalation_from }, sorted by id.
+//
+// The downstream tree_descend worker consumes activated_leaves[] as its
+// candidate set and only does focus-string semantic descent to filter.
+// The boolean activation logic is no longer the worker's responsibility.
+
+import { readdirSync, lstatSync, realpathSync, existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import matter from "gray-matter";
+
+import { evaluateActivation } from "../lib/activation-gate.mjs";
+
+const __thisDir = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__thisDir, "..", "..");
+
+// Cache: avoid re-walking the wiki on repeat invocations within one
+// process (tests, multi-run harnesses). Keyed by realpath of the wiki
+// root so a different repo gets its own cache.
+const _leavesCache = new Map();
+
+function isInside(parent, child) {
+  const rel = relative(parent, child);
+  return rel !== "" && !rel.startsWith("..") && !rel.startsWith(sep) && !rel.includes(":");
+}
+
+// Walk reviewers.wiki/ and parse every leaf's frontmatter. Returns an
+// array of { id, path, activation } objects (path is wiki-relative;
+// activation may be undefined if the leaf has no block).
+//
+// The wiki is small (~476 leaves today), and gray-matter is fast enough
+// that a full walk is fine to run on every review. If the corpus grows
+// dramatically, this becomes a candidate for a build-time index.
+function enumerateWikiLeavesWithActivation(repoRoot, { useCache = true } = {}) {
+  const wikiRoot = resolve(repoRoot, "reviewers.wiki");
+  if (!existsSync(wikiRoot)) return [];
+  let realRoot;
+  try {
+    realRoot = realpathSync(wikiRoot);
+  } catch {
+    return [];
+  }
+  if (useCache && _leavesCache.has(realRoot)) return _leavesCache.get(realRoot);
+
+  const leaves = [];
+  const stack = [realRoot];
+  const visited = new Set([realRoot]);
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      if (ent.name.startsWith(".")) continue;
+      const full = join(dir, ent.name);
+      let lst, realFull;
+      try {
+        lst = lstatSync(full);
+        realFull = realpathSync(full);
+      } catch {
+        continue;
+      }
+      if (!isInside(realRoot, realFull)) continue;
+      if (lst.isDirectory()) {
+        if (visited.has(realFull)) continue;
+        visited.add(realFull);
+        stack.push(realFull);
+        continue;
+      }
+      if (!ent.name.endsWith(".md") || ent.name === "index.md") continue;
+      let parsed;
+      try {
+        const text = readFileSync(realFull, "utf8");
+        parsed = matter(text);
+      } catch {
+        continue;
+      }
+      const id = parsed?.data?.id;
+      if (typeof id !== "string" || id.length === 0) continue;
+      const wikiRel = relative(realRoot, realFull).split(sep).join("/");
+      leaves.push({
+        id,
+        path: wikiRel,
+        activation: parsed.data.activation ?? undefined,
+      });
+    }
+  }
+
+  // Sort by id for deterministic ordering. The activation gate sorts its
+  // output too, but sorting input keeps escalation-pass iteration stable.
+  leaves.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  if (useCache) _leavesCache.set(realRoot, leaves);
+  return leaves;
+}
+
+// Spawn `git diff <base>..<head>` and return the unified diff body. Used
+// only for keyword_matches activation. Returns "" on any failure — the
+// gate then evaluates without keyword-match firing, file_globs and
+// structural_signals still work. Better to under-activate keyword
+// matches than to fault the run on a transient git issue.
+function fetchDiffText(base, head, repoRoot) {
+  if (!base || !head) return "";
+  const result = spawnSync(
+    "git",
+    ["diff", `${base}..${head}`],
+    { encoding: "utf8", cwd: repoRoot, maxBuffer: 32 * 1024 * 1024 },
+  );
+  if (result.status !== 0) return "";
+  return result.stdout ?? "";
+}
+
+export default async function activateLeaves({ env }) {
+  const projectProfile = env.project_profile ?? {};
+  const changedPaths = Array.isArray(env.changed_paths) ? env.changed_paths : [];
+  const args = env.args ?? {};
+
+  // base/head come from one of two sources:
+  //   1. env.base_sha / env.head_sha (seeded by @ctxr/fsm at run init from
+  //      --base-sha / --head-sha CLI args).
+  //   2. env.args.base / env.args.head (the orchestrator's raw arg bag).
+  // Prefer the engine-seeded fields since they're authoritative for the
+  // run; fall back to args for ad-hoc handlers / tests.
+  const base = env.base_sha ?? args.base ?? null;
+  const head = env.head_sha ?? args.head ?? null;
+
+  const leaves = enumerateWikiLeavesWithActivation(REPO_ROOT);
+  const diffText = fetchDiffText(base, head, REPO_ROOT);
+
+  const { activated, descent_signals } = evaluateActivation({
+    leaves,
+    changed_paths: changedPaths,
+    project_profile: projectProfile,
+    diff_text: diffText,
+  });
+
+  const activatedLeaves = activated.map((leaf) => ({
+    id: leaf.id,
+    path: leaf.path,
+    activation_match: descent_signals[leaf.id] ?? [],
+  }));
+
+  return { activated_leaves: activatedLeaves };
+}
+
+// Exported helpers for direct testing without spawning the full FSM driver.
+export { enumerateWikiLeavesWithActivation, fetchDiffText };

--- a/tests/unit/activate-leaves.test.js
+++ b/tests/unit/activate-leaves.test.js
@@ -1,0 +1,113 @@
+// Unit tests for scripts/inline-states/activate-leaves.mjs — the
+// inline-state handler that runs the activation gate over every wiki
+// leaf BEFORE tree_descend (B6 reframe; PR C of #70 divergence #4).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import activateLeaves, {
+  enumerateWikiLeavesWithActivation,
+  fetchDiffText,
+} from "../../scripts/inline-states/activate-leaves.mjs";
+
+test("enumerateWikiLeavesWithActivation: walks the corpus and returns leaves with activation blocks", () => {
+  const leaves = enumerateWikiLeavesWithActivation(
+    new URL("../..", import.meta.url).pathname,
+    { useCache: false },
+  );
+  assert.ok(leaves.length > 0, "wiki should have at least one leaf");
+  // All entries have a string id and a path.
+  for (const leaf of leaves) {
+    assert.equal(typeof leaf.id, "string");
+    assert.match(leaf.id, /^[a-z][a-z0-9-]*$/);
+    assert.equal(typeof leaf.path, "string");
+    assert.ok(leaf.path.endsWith(".md"));
+  }
+  // Ids are unique.
+  const ids = new Set(leaves.map((l) => l.id));
+  assert.equal(ids.size, leaves.length, "leaf ids must be unique");
+  // Sorted by id (deterministic ordering).
+  for (let i = 1; i < leaves.length; i++) {
+    assert.ok(leaves[i - 1].id <= leaves[i].id, `not sorted at index ${i}`);
+  }
+  // At least one leaf has an activation block (otherwise the gate is a
+  // no-op and this test is a tautology).
+  const withActivation = leaves.filter((l) => l.activation);
+  assert.ok(withActivation.length > 0, "expected at least one leaf with activation:");
+});
+
+test("fetchDiffText: returns empty string on missing/invalid SHAs without throwing", () => {
+  // Use sha-shaped strings that are valid but don't exist in the repo.
+  const text = fetchDiffText(
+    "0000000000000000000000000000000000000001",
+    "0000000000000000000000000000000000000002",
+    new URL("../..", import.meta.url).pathname,
+  );
+  assert.equal(typeof text, "string");
+  assert.equal(text, "", "expected empty string on git diff failure");
+});
+
+test("activateLeaves: empty changed_paths still produces a structurally valid output", async () => {
+  const out = await activateLeaves({
+    env: {
+      project_profile: { languages: ["javascript"] },
+      changed_paths: [],
+      args: {},
+      base_sha: null,
+      head_sha: null,
+    },
+  });
+  assert.ok(Array.isArray(out.activated_leaves));
+  // No diff body, no changed paths → no file_globs / keyword_matches /
+  // structural_signals fire, no leaves activated.
+  // (structural_signals could fire on language=javascript — but only if
+  // some leaf declares "javascript" in its activation.structural_signals[].
+  // The test just asserts the output shape is valid.)
+  for (const leaf of out.activated_leaves) {
+    assert.equal(typeof leaf.id, "string");
+    assert.equal(typeof leaf.path, "string");
+    assert.ok(Array.isArray(leaf.activation_match));
+    assert.ok(leaf.activation_match.length > 0);
+    for (const sig of leaf.activation_match) {
+      assert.ok(
+        ["file_globs", "keyword_matches", "structural_signals", "escalation_from"].includes(sig),
+        `unknown signal: ${sig}`,
+      );
+    }
+  }
+});
+
+test("activateLeaves: file_globs activation fires deterministically on a JS-shaped diff", async () => {
+  // Use changed_paths shaped like the actual PR A diff. file_globs
+  // covering **/*.mjs / **/*.js will fire for any leaf with those globs.
+  const out1 = await activateLeaves({
+    env: {
+      project_profile: { languages: ["javascript"] },
+      changed_paths: ["scripts/run-review.mjs", "tests/integration/end-to-end-runner.test.js"],
+      args: {},
+      base_sha: null,
+      head_sha: null,
+    },
+  });
+  const out2 = await activateLeaves({
+    env: {
+      project_profile: { languages: ["javascript"] },
+      changed_paths: ["scripts/run-review.mjs", "tests/integration/end-to-end-runner.test.js"],
+      args: {},
+      base_sha: null,
+      head_sha: null,
+    },
+  });
+  // Determinism: identical input → byte-identical output (modulo array
+  // order, which the gate sorts).
+  assert.deepEqual(
+    out1.activated_leaves.map((l) => l.id),
+    out2.activated_leaves.map((l) => l.id),
+    "two identical runs must produce identical activated_leaves",
+  );
+  // At least one JS-relevant leaf activated.
+  assert.ok(
+    out1.activated_leaves.length > 0,
+    "expected at least one leaf to activate on JS-shaped diff",
+  );
+});


### PR DESCRIPTION
Refs #70 (audit divergence #4).

## Summary

Lifts the activation-gate evaluation into a new FSM inline state `activate_leaves` that runs between `risk_tier_triage` and `tree_descend`. Removes the architectural blind spot where the tree-descender worker was nominally responsible for invoking `scripts/lib/activation-gate.mjs`'s `evaluateActivation()` but the orchestrator had no way to verify the call actually happened.

This is the long-tracked **B6 reframe** referenced in the original `code-reviewer.md` (now `docs/code-reviewer-design.md`) Step 3 design notes.

## Mechanics

- New inline state `activate_leaves`. Walks `reviewers.wiki/` once via `gray-matter`, fetches the unified diff via `git diff <base>..<head>`, calls `evaluateActivation()`, emits `activated_leaves: [{id, path, activation_match}]` sorted by id.
- `risk_tier_triage` now transitions to `activate_leaves` instead of `tree_descend` on the non-trivial path.
- `activate_leaves` short-circuits to `stage_a_empty` if zero leaves activate; otherwise → `tree_descend`.
- `tree_descend` worker prompt rewritten: now consumes `activated_leaves[]` from inputs, only does focus-string semantic descent to filter, copies `id`/`path`/`activation_match` verbatim into `stage_a_candidates[]`. Explicit ban on re-evaluating activation or reading any leaf `.md` file.
- Schema externally unchanged (`stage_a_candidates` shape preserved) — downstream `llm_trim`, validators, and the trim-output-validator are unaffected.

## Test plan

- [x] `npm run validate:fsm` — 0 errors, 15 states (was 14).
- [x] `npm run lint` — 0 errors over 562 files.
- [x] `npm test` — 192/192 (was 188; +4 from new activate-leaves suite).
- [x] Smoke: `--start --base SHA --head SHA` then `--continue` with project-scanner output → brief advances through `risk_tier_triage` → `activate_leaves` → `tree_descend`; `tree_descend` brief.inputs contains `activated_leaves` (169 entries on a synthetic JS-shaped diff).
- [ ] CI green.

## Files

```
new:        scripts/inline-states/activate-leaves.mjs    # the handler (~120 lines incl. comments)
new:        tests/unit/activate-leaves.test.js           # 4 unit cases (enumerate, diff fetch, empty, deterministic)
modified:   fsm/code-reviewer.fsm.yaml                   # +activate_leaves state, transitions rewired
modified:   fsm/workers/tree-descender.md                # consume activated_leaves[]; ban re-evaluation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)