### PR TITLE
feat(skill): run-dir as the source of truth (closes #76)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-code-review
-description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements. Runs an FSM-driven, deterministic, manifest-producing code-review pipeline via scripts/run-review.mjs. The LLM is a worker, not the orchestrator.
+description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements. Runs an FSM-driven, deterministic, manifest-producing code-review pipeline via scripts/run-review.mjs. The runner is the source of truth; briefs and outputs live on disk under <run_dir>/workers/. The LLM is a worker, not the orchestrator.
 ---
 
 # skill-code-review
@@ -28,17 +28,20 @@ The brief has this shape (only the fields you need):
     "prompt_template":  <path under fsm/, e.g. "workers/project-scanner.md">,
     "prompt_body":      <bytes of the worker prompt file, shipped with the brief>,
     "response_schema":  <JSON Schema the worker output is validated against>
-  }
+  },
+  "outputs_path":       <canonical path to write the worker's JSON output: <run_dir>/workers/<state>-output.json>
 }
 ```
 
 1. Build the worker prompt by concatenating `brief.worker.prompt_body` (already provided) with the `brief.inputs` values the worker needs. **Do not** Read the file at `brief.worker.prompt_template` — the runner already shipped its bytes in `prompt_body`. **Do not** read anything else (not the wiki, not the design doc, not the gate predicates, not other workers).
 2. Dispatch via the `Agent` tool. The worker must return a single JSON object satisfying `brief.worker.response_schema`.
-3. Write the response to a temp file (`/tmp/worker-out-<run_id>.json` is fine), then call:
+3. Write the worker's response to **`brief.outputs_path`** (the runner has already pre-allocated this canonical path under `<run_dir>/workers/<state>-output.json`). Then call:
 
    ```
-   node scripts/run-review.mjs --continue --run-id <run_id> --outputs-file <path>
+   node scripts/run-review.mjs --continue --run-id <run_id>
    ```
+
+   No `--outputs-file` flag is needed — the runner defaults to `brief.outputs_path` when it's omitted. **Do not invent your own filename.** Doing so risks cross-run collisions, stale-file pickup, and breaks the run-dir's audit-trail invariant that every output sits next to its commit trace.
 
 4. Loop on the next stdout line.
 
@@ -52,7 +55,7 @@ Step-by-step:
 2. `brief.inputs.picked_leaves[]` arrives with each leaf's `body` already baked in (the runner ships it; you don't Read leaf files).
 3. For each leaf in `picked_leaves`, build a specialist prompt by concatenating: the per-specialist template (`brief.worker.prompt_body`) + that leaf's `body` + `brief.inputs.project_profile` + a filtered `git diff` (scope by the leaf's `activation.file_globs` from its frontmatter when present, else the full changed-file set) + any `tool_results` entries whose `name` matches a tool the leaf declares.
 4. Emit ONE message containing K parallel `Agent` tool calls — one per leaf. Each Agent must run **blind** (no specialist sees another's output). Each returns a single JSON object matching the per-specialist response shape (id, status, runtime_ms, tokens_in, tokens_out, findings, optional skip_reason). See `fsm/workers/specialist.md` for the contract.
-5. Aggregate the K responses into `{ "specialist_outputs": [<k objects>] }` (must match `brief.worker.response_schema`). Write to a temp file. `--continue` with that file.
+5. Aggregate the K responses into `{ "specialist_outputs": [<k objects>] }` (must match `brief.worker.response_schema`). Write to **`brief.outputs_path`** (same canonical location as every other worker state — `<run_dir>/workers/dispatch_specialists-output.json`). Then call `node scripts/run-review.mjs --continue --run-id <run_id>`. Do not invent a filename.
 
 **Why this is special:** the previous design dispatched a single coordinator-Agent that fanned out to K specialists internally. That hid whether K real Agents actually ran (the audit in #70 surfaced this as divergence #3 — "blind specialists" was unverifiable). The orchestrator-side dispatch makes the K Agent calls visible in your tool-use trace and to the runner's FSM trace.
 
@@ -74,6 +77,20 @@ Step-by-step:
 ### On `{"status": "fault" | "error", ...}`
 
 **Any** fault or error output is a stop signal — even if other output (such as a `report.md` on disk, or a Manifest line) appears valid alongside it. Surface the fault payload to the user verbatim. Do not retry silently. Do not fall back to a manual review. Do not editorialise the fault as "cosmetic" or "known": that judgement is the user's, not yours.
+
+### Recovery: lost the awaiting_worker brief on stdout?
+
+The runner persists every awaiting_worker brief to disk at **`<run_dir>/workers/<state>-brief.json`** at the moment it pauses. If you piped `--continue` stdout through a summarizer or otherwise lost the next brief, you do **not** need to retry `--continue` (which would fault — the FSM has already advanced past the previous worker). Instead:
+
+```
+node scripts/run-review.mjs --resume --run-id <run_id>
+```
+
+This is a read-only operation: it reads the manifest's `current_state`, reads the brief file from disk, and re-emits it on stdout in the same `{"status": "awaiting_worker", "run_id", "brief"}` envelope as `--start` produces. After that, continue with `--continue` as normal.
+
+If even that's not enough (e.g. stdout buffering issues), you can `cat <run_dir>/workers/<state>-brief.json` directly — the file IS the canonical brief. Stdout is a convenience signal; the run-dir is the source of truth.
+
+**Do not** re-run `--continue` with the previous worker's outputs to "see what happens." The FSM has already committed those outputs and advanced; a second commit will fail `output_schema_violation` against the next state's schema.
 
 ---
 

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -29,12 +29,12 @@
 // handler emits a `fault` so callers can react uniformly.
 
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync, mkdtempSync, existsSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdtempSync, existsSync, rmSync, renameSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { tmpdir, platform } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { resolveSettings, runEnv, runDirPath, readLock } from "@ctxr/fsm";
+import { resolveSettings, runEnv, runDirPath, readLock, readManifest } from "@ctxr/fsm";
 
 import {
   resolveReplayMode,
@@ -236,6 +236,77 @@ export function enrichBriefWithSpecialistBodies(brief) {
       picked_leaves: enrichedLeaves,
     },
   };
+}
+
+// PR for #76: run-dir as the source of truth.
+//
+// Two helpers compute the canonical per-state, per-run-id paths under
+// <run_dir>/workers/. The directory is pre-created by @ctxr/fsm's
+// ensureRunDir on every fsm-next invocation, so no mkdir boilerplate is
+// needed here.
+//
+// Layout:
+//   <run_dir>/workers/<state>-brief.json   ← runner writes on every pause
+//   <run_dir>/workers/<state>-output.json  ← orchestrator writes; --continue reads
+//
+// Both files round-trip through JSON.parse / JSON.stringify with no
+// special framing — they are the canonical artifacts the orchestrator
+// reads from disk.
+export function defaultOutputsPath(runId, state) {
+  if (!runId || !state) return null;
+  const storageRoot = resolveStorageRoot();
+  return join(runDirPath(runId, { storageRoot }), "workers", `${state}-output.json`);
+}
+
+export function defaultBriefPath(runId, state) {
+  if (!runId || !state) return null;
+  const storageRoot = resolveStorageRoot();
+  return join(runDirPath(runId, { storageRoot }), "workers", `${state}-brief.json`);
+}
+
+// Inject brief.outputs_path into every awaiting_worker brief on the way
+// out of parseFsmCliResult. Pure function, idempotent; passes through
+// briefs that are not at a worker pause.
+//
+// SKILL.md mandates that the orchestrator write the worker's response
+// to brief.outputs_path. The runner defaults --continue's --outputs-file
+// to this same path, so the orchestrator does not need to thread the
+// path back via CLI args.
+export function enrichBriefWithOutputsPath(brief) {
+  if (!brief?.has_worker) return brief;
+  if (!brief.run_id || !brief.state) return brief;
+  const outputsPath = defaultOutputsPath(brief.run_id, brief.state);
+  if (!outputsPath) return brief;
+  return { ...brief, outputs_path: outputsPath };
+}
+
+// Persist a fully-enriched awaiting_worker brief to
+// <run_dir>/workers/<state>-brief.json atomically (write to a tmp
+// sibling, then rename). The brief on disk is the canonical record;
+// stdout is a convenience signal but not load-bearing — if the
+// orchestrator loses the stdout brief, --resume reads this file.
+//
+// Best-effort: any I/O failure is swallowed. The orchestrator can still
+// use stdout if disk persistence happens to fail. We do not want a
+// transient ENOSPC / EACCES on brief-disk-write to fault out a run that
+// would otherwise advance fine.
+export function writeBriefToDisk(brief) {
+  if (!brief?.has_worker) return;
+  if (!brief.run_id || !brief.state) return;
+  const briefPath = defaultBriefPath(brief.run_id, brief.state);
+  if (!briefPath) return;
+  const tmpPath = `${briefPath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    writeFileSync(tmpPath, JSON.stringify(brief, null, 2));
+    renameSync(tmpPath, briefPath);
+  } catch {
+    // Best-effort cleanup of the tmp file on failure; ignore secondary errors.
+    try {
+      rmSync(tmpPath, { force: true });
+    } catch {
+      // ignore
+    }
+  }
 }
 
 function hashKeyForBrief(brief, env) {
@@ -541,8 +612,15 @@ export function parseFsmCliResult(result, label) {
     //      dispatches K specialists in parallel without K separate Reads.
     // Both helpers are idempotent and pass through untouched payloads
     // they don't apply to (terminal status, non-worker state, etc.).
-    const enriched = enrichBriefWithSpecialistBodies(
-      enrichBriefWithPromptBody(payload),
+    // Three enrichers, applied innermost-first:
+    //   1. enrichBriefWithPromptBody       — bake the worker's prompt template bytes
+    //   2. enrichBriefWithSpecialistBodies — for dispatch_specialists, bake each leaf body
+    //   3. enrichBriefWithOutputsPath      — inject the canonical outputs_path
+    // Briefs without a worker (terminal payloads, etc.) pass through untouched.
+    const enriched = enrichBriefWithOutputsPath(
+      enrichBriefWithSpecialistBodies(
+        enrichBriefWithPromptBody(payload),
+      ),
     );
     return { ok: true, payload: enriched };
   } catch (err) {
@@ -641,6 +719,11 @@ export function handleWorkerStateBrief(brief, runId, opts = {}, _deps = {}) {
   // --replay-mode=record` will not have a stash to record against;
   // record mode is per-run, not retroactive.
   if (replayMode === "live") {
+    // Persist the brief to <run_dir>/workers/<state>-brief.json before
+    // returning. The on-disk file is the canonical brief; stdout is
+    // a redundant convenience. Lost stdout (orchestrator pipes through
+    // a summarizer, etc.) becomes recoverable via --resume.
+    writeBriefToDisk(brief);
     return {
       kind: "pause",
       payload: { status: "awaiting_worker", run_id: runId, brief },
@@ -759,6 +842,10 @@ export function handleWorkerStateBrief(brief, runId, opts = {}, _deps = {}) {
     };
   }
 
+  // Persist the brief to <run_dir>/workers/<state>-brief.json before
+  // returning. Same reasoning as the live-mode branch above; the disk
+  // file is the canonical brief regardless of replay mode.
+  writeBriefToDisk(brief);
   return {
     kind: "pause",
     payload: { status: "awaiting_worker", run_id: runId, brief },
@@ -847,6 +934,9 @@ async function main() {
   if (args.start && args.continue) {
     fail("--start and --continue are mutually exclusive; pick one");
   }
+  if ((args.start && args.resume) || (args.continue && args.resume)) {
+    fail("--resume is mutually exclusive with --start and --continue");
+  }
 
   if (args.start) {
     const baseSha = args.base ?? args["base-sha"];
@@ -903,22 +993,51 @@ async function main() {
 
   if (args.continue) {
     const runId = args["run-id"];
-    const outputsFile = args["outputs-file"];
-    if (!runId || !outputsFile) {
-      fail("--continue requires --run-id <id> and --outputs-file <path>");
+    if (!runId) {
+      fail("--continue requires --run-id <id>");
     }
-    // parseArgs sets bare flags to boolean `true`; require the value to
-    // actually be a non-empty string before forwarding it as a path / id.
     if (typeof runId !== "string" || runId.length === 0) {
       fail("--run-id requires a value (got bare flag)");
-    }
-    if (typeof outputsFile !== "string" || outputsFile.length === 0) {
-      fail("--outputs-file requires a path argument");
     }
     if (!isValidRunId(runId)) {
       // Reject path-traversal payloads (`../`, `/etc/passwd`, …) before
       // `runId` can land in a filename inside SCRATCH_DIR.
       fail(`--run-id must be lowercase alnum + dashes, 3-64 chars; got: ${runId}`);
+    }
+
+    // --outputs-file is now optional. When omitted, default to the
+    // canonical path the brief shipped as `outputs_path`:
+    //   <run_dir>/workers/<current_state>-output.json
+    // The runner reads the manifest's current_state to compose the
+    // path. SKILL.md instructs the orchestrator to write to
+    // brief.outputs_path and call --continue --run-id <id> without
+    // --outputs-file in the common case.
+    let outputsFile = args["outputs-file"];
+    if (outputsFile === undefined) {
+      const storageRoot = resolveStorageRoot();
+      const manifest = readManifest(runId, { storageRoot });
+      if (!manifest) {
+        fail(
+          `--continue: no manifest found for run-id "${runId}"; cannot resolve default --outputs-file. Run --start first, or pass --outputs-file <path> explicitly.`,
+          { run_id: runId },
+        );
+      }
+      const currentState = manifest.current_state;
+      if (!currentState) {
+        fail(
+          `--continue: manifest has no current_state for run-id "${runId}"; cannot resolve default --outputs-file. Pass --outputs-file <path> explicitly.`,
+          { run_id: runId },
+        );
+      }
+      outputsFile = defaultOutputsPath(runId, currentState);
+      if (!existsSync(outputsFile)) {
+        fail(
+          `--continue: default outputs file not found at "${outputsFile}". Either write your worker output to that path (the brief shipped it as outputs_path) or pass --outputs-file <path> explicitly.`,
+          { run_id: runId, current_state: currentState, expected_path: outputsFile },
+        );
+      }
+    } else if (typeof outputsFile !== "string" || outputsFile.length === 0) {
+      fail("--outputs-file requires a path argument");
     }
     const outputs = readJsonFile(outputsFile, "--outputs-file");
 
@@ -1042,10 +1161,90 @@ async function main() {
     return;
   }
 
+  if (args.resume) {
+    // --resume is a read-only recovery path. The orchestrator (the LLM)
+    // pipes --continue stdout through summarizers / parsers and loses
+    // the next awaiting_worker brief; --resume re-emits it from the
+    // canonical on-disk artifact at <run_dir>/workers/<state>-brief.json.
+    //
+    // No subprocess. No lock dance. The brief on disk was written by
+    // the runner during the previous pause (see writeBriefToDisk in
+    // handleWorkerStateBrief). All this does is read the manifest's
+    // current_state and read the matching brief file.
+    const runId = args["run-id"];
+    if (!runId) {
+      fail("--resume requires --run-id <id>");
+    }
+    if (typeof runId !== "string" || runId.length === 0) {
+      fail("--run-id requires a value (got bare flag)");
+    }
+    if (!isValidRunId(runId)) {
+      fail(`--run-id must be lowercase alnum + dashes, 3-64 chars; got: ${runId}`);
+    }
+    const storageRoot = resolveStorageRoot();
+    const manifest = readManifest(runId, { storageRoot });
+    if (!manifest) {
+      fail(
+        `--resume: no manifest found for run-id "${runId}". Either the run never started or the run-dir was removed.`,
+        { run_id: runId },
+      );
+    }
+    // Terminal / faulted runs have no brief to resume — surface the
+    // manifest's verdict / fault state directly so the orchestrator
+    // sees the same shape it would have seen at the original
+    // terminal pause.
+    if (manifest.status === "completed") {
+      emit({
+        status: "terminal",
+        run_id: runId,
+        verdict: manifest.verdict ?? null,
+        run_dir_path: runDirPath(runId, { storageRoot }),
+      });
+      return;
+    }
+    if (manifest.status === "faulted") {
+      emit({
+        status: "fault",
+        run_id: runId,
+        fault: {
+          state: manifest.current_state ?? null,
+          reason: manifest.fault_reason ?? "run faulted; see manifest",
+        },
+      });
+      return;
+    }
+    const currentState = manifest.current_state;
+    if (!currentState) {
+      fail(
+        `--resume: manifest has no current_state for run-id "${runId}".`,
+        { run_id: runId, status: manifest.status },
+      );
+    }
+    const briefPath = defaultBriefPath(runId, currentState);
+    if (!briefPath || !existsSync(briefPath)) {
+      fail(
+        `--resume: no brief file at "${briefPath}". Either this run pre-dates run-dir-as-source-of-truth (briefs were not persisted) or the file was removed. Try re-running --start, or use @ctxr/fsm's fsm-next --resume directly.`,
+        { run_id: runId, current_state: currentState, expected_path: briefPath },
+      );
+    }
+    let brief;
+    try {
+      brief = JSON.parse(readFileSync(briefPath, "utf8"));
+    } catch (err) {
+      fail(
+        `--resume: brief file at "${briefPath}" is unreadable or malformed: ${err?.message ?? String(err)}`,
+        { run_id: runId, current_state: currentState, brief_path: briefPath },
+      );
+    }
+    emit({ status: "awaiting_worker", run_id: runId, brief });
+    return;
+  }
+
   fail(
     "Usage:\n" +
       "  run-review.mjs --start --base <sha> --head <sha> [--args-file <path>] [--replay-mode <live|record|replay>]\n" +
-      "  run-review.mjs --continue --run-id <id> --outputs-file <path> [--replay-mode <live|record|replay>]",
+      "  run-review.mjs --continue --run-id <id> [--outputs-file <path>] [--replay-mode <live|record|replay>]\n" +
+      "  run-review.mjs --resume --run-id <id>",
   );
 }
 

--- a/tests/integration/end-to-end-runner.test.js
+++ b/tests/integration/end-to-end-runner.test.js
@@ -92,11 +92,36 @@ test("runner --start: emits awaiting_worker JSON with project-scanner brief and 
     "brief.worker.prompt_body must equal fsm/workers/project-scanner.md byte-for-byte",
   );
 
+  // PR for #76: brief carries a canonical outputs_path under
+  // <run_dir>/workers/<state>-output.json. Assert it's present and
+  // shaped right.
+  assert.equal(typeof firstLine.brief.outputs_path, "string");
+  assert.ok(
+    firstLine.brief.outputs_path.endsWith("workers/scan_project-output.json"),
+    `outputs_path should end with workers/scan_project-output.json; got ${firstLine.brief.outputs_path}`,
+  );
+
   // The FSM engine seeds the manifest at run-init with base_sha / head_sha
   // taken from --base / --head. Confirm assert-fresh-run.mjs accepts it.
   const settings = resolveSettings({ fsmName: "code-reviewer" }, REPO_ROOT);
   const storageRoot = resolve(REPO_ROOT, settings.storageRoot);
   const runDir = runDirPath(firstLine.run_id, { storageRoot });
+
+  // PR for #76: the runner persists the brief to
+  // <run_dir>/workers/<state>-brief.json on every pause. Assert the
+  // file exists and matches the stdout brief byte-for-byte.
+  const briefOnDiskPath = `${runDir}/workers/scan_project-brief.json`;
+  assert.ok(
+    existsSync(briefOnDiskPath),
+    `expected on-disk brief at ${briefOnDiskPath}`,
+  );
+  const briefOnDisk = JSON.parse(readFileSync(briefOnDiskPath, "utf8"));
+  assert.deepEqual(
+    briefOnDisk,
+    firstLine.brief,
+    "<run_dir>/workers/scan_project-brief.json must equal the stdout brief",
+  );
+
   const manifestPath = `${runDir}/manifest.json`;
   assert.ok(
     existsSync(manifestPath),
@@ -158,9 +183,14 @@ test("runner --start → --continue: chains across subprocesses without lock_not
   // Trivial-tier project-scanner output: 1 file, 1 line changed, no
   // risk-path match → risk_tier_triage emits tier=trivial → FSM jumps to
   // short_circuit_exit, writes the run dir, emits stdout, hits terminal.
-  const tmpFile = `/tmp/e2e-runner-${runId}.json`;
+  //
+  // PR for #76: write to brief.outputs_path (the canonical path the
+  // runner shipped), and call --continue WITHOUT --outputs-file so the
+  // runner's default-path lookup is exercised.
+  const outputsPath = startLine.brief.outputs_path;
+  assert.equal(typeof outputsPath, "string");
   writeFileSync(
-    tmpFile,
+    outputsPath,
     JSON.stringify({
       project_profile: {
         languages: ["md"],
@@ -180,8 +210,7 @@ test("runner --start → --continue: chains across subprocesses without lock_not
         "--continue",
         "--run-id",
         runId,
-        "--outputs-file",
-        tmpFile,
+        // No --outputs-file: runner defaults to brief.outputs_path.
       ],
       { encoding: "utf8", cwd: REPO_ROOT, timeout: 30_000 },
     );
@@ -249,6 +278,69 @@ test("runner --start → --continue: chains across subprocesses without lock_not
     const ok = validateRun({ runId, base: baseSha, head: headSha, storageRoot });
     assert.equal(ok.ok, true, `validateRun failed after --continue: ${JSON.stringify(ok)}`);
   } finally {
-    // tmpFile cleanup is best-effort; the test machine's /tmp gets swept.
+    // outputsPath cleanup is best-effort; the run-dir is gitignored.
   }
+});
+
+test("runner --resume: re-emits the current pause brief from disk (regression for #76)", () => {
+  // Drives --start, captures the brief on disk, then runs --resume
+  // and asserts the runner re-emits the same brief from
+  // <run_dir>/workers/<state>-brief.json without spawning fsm-next
+  // and without touching the lock.
+  const baseSha = "3333333333333333333333333333333333333333";
+  const headSha = "4444444444444444444444444444444444444444";
+
+  const start = spawnSync(
+    process.execPath,
+    [
+      "scripts/run-review.mjs",
+      "--start",
+      "--base",
+      baseSha,
+      "--head",
+      headSha,
+    ],
+    { encoding: "utf8", cwd: REPO_ROOT, timeout: 30_000 },
+  );
+  assert.equal(start.status, 0, `--start exited ${start.status}; stderr: ${start.stderr}`);
+  const startLine = JSON.parse(start.stdout.split("\n").filter(Boolean)[0]);
+  const runId = startLine.run_id;
+  const originalBrief = startLine.brief;
+
+  // The runner persisted the brief to disk during the pause. Confirm
+  // the file exists under <run_dir>/workers/<state>-brief.json.
+  const settings = resolveSettings({ fsmName: "code-reviewer" }, REPO_ROOT);
+  const storageRoot = resolve(REPO_ROOT, settings.storageRoot);
+  const runDir = runDirPath(runId, { storageRoot });
+  const briefOnDiskPath = `${runDir}/workers/scan_project-brief.json`;
+  assert.ok(existsSync(briefOnDiskPath), `expected ${briefOnDiskPath}`);
+
+  // --resume re-emits the brief.
+  const resume = spawnSync(
+    process.execPath,
+    [
+      "scripts/run-review.mjs",
+      "--resume",
+      "--run-id",
+      runId,
+    ],
+    { encoding: "utf8", cwd: REPO_ROOT, timeout: 30_000 },
+  );
+  assert.equal(
+    resume.status,
+    0,
+    `--resume exited ${resume.status}; stdout=${resume.stdout} stderr=${resume.stderr}`,
+  );
+  const resumeLine = JSON.parse(resume.stdout.split("\n").filter(Boolean)[0]);
+  assert.equal(resumeLine.status, "awaiting_worker");
+  assert.equal(resumeLine.run_id, runId);
+
+  // The resumed brief equals the original brief from --start
+  // byte-for-byte (modulo no nondeterministic fields — both come from
+  // the same disk file).
+  assert.deepEqual(
+    resumeLine.brief,
+    originalBrief,
+    "--resume must re-emit the same brief --start did, byte-for-byte",
+  );
 });

--- a/tests/unit/brief-disk-persistence.test.js
+++ b/tests/unit/brief-disk-persistence.test.js
@@ -1,0 +1,116 @@
+// Unit tests for the run-dir-as-source-of-truth helpers (#76):
+//   - defaultOutputsPath / defaultBriefPath  — canonical per-state paths
+//   - enrichBriefWithOutputsPath             — third enricher in parseFsmCliResult
+//   - writeBriefToDisk                       — atomic brief persistence
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, mkdtempSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  defaultOutputsPath,
+  defaultBriefPath,
+  enrichBriefWithOutputsPath,
+  writeBriefToDisk,
+} from "../../scripts/run-review.mjs";
+
+test("defaultOutputsPath: returns null on missing run_id or state", () => {
+  assert.equal(defaultOutputsPath(null, "scan_project"), null);
+  assert.equal(defaultOutputsPath("20260429-185000-a3618a4", null), null);
+  assert.equal(defaultOutputsPath("", ""), null);
+});
+
+test("defaultOutputsPath: produces a path containing run-id segments and the state suffix", () => {
+  const path = defaultOutputsPath("20260429-185000-a3618a4", "scan_project");
+  assert.ok(path.endsWith("workers/scan_project-output.json"), `unexpected suffix: ${path}`);
+  // run-id format: yyyymmdd-hhmmss-hash7. Path layout includes year/month/day
+  // segments and a 2-char shard from the hash. Confirm those tokens appear.
+  assert.match(path, /\/2026\/04\/29\//);
+  assert.match(path, /\/a3\/618a4\//);
+});
+
+test("defaultBriefPath: produces a path with the brief suffix", () => {
+  const path = defaultBriefPath("20260429-185000-a3618a4", "tree_descend");
+  assert.ok(path.endsWith("workers/tree_descend-brief.json"), `unexpected suffix: ${path}`);
+});
+
+test("enrichBriefWithOutputsPath: passes through briefs with no worker", () => {
+  // status: "terminal" payloads, faulted shapes, etc.
+  assert.deepEqual(enrichBriefWithOutputsPath({ status: "terminal" }), { status: "terminal" });
+  assert.deepEqual(enrichBriefWithOutputsPath({ has_worker: false }), { has_worker: false });
+});
+
+test("enrichBriefWithOutputsPath: passes through briefs missing run_id or state", () => {
+  const a = enrichBriefWithOutputsPath({ has_worker: true, state: "scan_project" });
+  assert.equal(a.outputs_path, undefined);
+  const b = enrichBriefWithOutputsPath({ has_worker: true, run_id: "x" });
+  assert.equal(b.outputs_path, undefined);
+});
+
+test("enrichBriefWithOutputsPath: injects outputs_path on a complete worker brief", () => {
+  const brief = {
+    has_worker: true,
+    run_id: "20260429-185000-a3618a4",
+    state: "tree_descend",
+    worker: { role: "tree-descender" },
+  };
+  const out = enrichBriefWithOutputsPath(brief);
+  assert.ok(out.outputs_path.endsWith("workers/tree_descend-output.json"));
+  // Original not mutated.
+  assert.equal(brief.outputs_path, undefined);
+});
+
+test("enrichBriefWithOutputsPath: idempotent (applying twice yields the same outputs_path)", () => {
+  const brief = {
+    has_worker: true,
+    run_id: "20260429-185000-a3618a4",
+    state: "scan_project",
+  };
+  const a = enrichBriefWithOutputsPath(brief);
+  const b = enrichBriefWithOutputsPath(a);
+  assert.equal(a.outputs_path, b.outputs_path);
+});
+
+test("writeBriefToDisk: passes through silently when no worker / missing fields", () => {
+  // Should not throw on these shapes.
+  writeBriefToDisk({ status: "terminal" });
+  writeBriefToDisk({ has_worker: false });
+  writeBriefToDisk({ has_worker: true, run_id: "x" });
+  // No assertion — the test passing means nothing was thrown.
+});
+
+test("writeBriefToDisk: atomically writes the brief to <run_dir>/workers/<state>-brief.json", () => {
+  // We need a real <run_dir>/workers/ directory to write into. Use a
+  // synthetic run-id that resolves under .skill-code-review/. The
+  // workers/ subdirectory is normally created by @ctxr/fsm's
+  // ensureRunDir on fsm-next; we mkdir it here to mirror that
+  // contract for an isolated unit test.
+  const runId = "20991231-235959-cafef00";
+  const state = "test_state";
+  const briefPath = defaultBriefPath(runId, state);
+  const workersDir = dirname(briefPath);
+  mkdirSync(workersDir, { recursive: true });
+
+  try {
+    const brief = {
+      has_worker: true,
+      run_id: runId,
+      state,
+      worker: { role: "test" },
+      outputs_path: "/some/path.json",
+    };
+    writeBriefToDisk(brief);
+    assert.ok(existsSync(briefPath), `expected brief at ${briefPath}`);
+    const onDisk = JSON.parse(readFileSync(briefPath, "utf8"));
+    assert.deepEqual(onDisk, brief);
+    // No tmp file leaked alongside.
+    const leaks = readdirSync(workersDir).filter((n) => n.includes(".tmp-"));
+    assert.deepEqual(leaks, [], "no .tmp leftover");
+  } finally {
+    // Best-effort cleanup so repeat runs don't accumulate synthetic
+    // run-dirs under .skill-code-review/.
+    rmSync(briefPath, { force: true });
+  }
+});


### PR DESCRIPTION
Closes #76.

## Summary

Demotes stdout from "load-bearing brief carrier" to "redundant convenience signal." The runner persists every awaiting_worker brief to disk and ships a canonical outputs path in the brief; `--continue` defaults to that path; new `--resume` mode reads the brief from disk and re-emits it.

After this PR, every concrete workflow hole I've hit during the audit-driven runs is closed structurally.

## Mechanisms

- **Brief on disk.** Every paused brief is written atomically to `<run_dir>/workers/<state>-brief.json`. Lost stdout is no longer fatal.
- **Canonical outputs path.** `enrichBriefWithOutputsPath` injects `outputs_path: <run_dir>/workers/<state>-output.json` into every brief. The orchestrator does not invent filenames.
- **`--continue` defaults `--outputs-file`.** Omit the flag; runner reads the manifest's `current_state` and resolves the canonical path. SKILL.md instructs `--continue --run-id <id>` without `--outputs-file` in the common case.
- **`--resume --run-id <id>`.** Read-only. Reads manifest, resolves `current_state`, reads `<run_dir>/workers/<state>-brief.json`, emits as `{"status":"awaiting_worker","run_id","brief"}`. No subprocess; no lock dance.

## Mapping the four holes hit during PR #70's audit-driven runs to fixes

| Hole | Fix |
|---|---|
| Pipe `--continue` stdout through summarizer, lost brief | Brief on disk; `--resume` reads it |
| Used `/tmp/wo-scan.json` instead of run-id-qualified name | Runner ships `outputs_path`; `--continue` defaults to it |
| Called `--continue` twice with same outputs, double-commit | SKILL.md Recovery section forbids; points at `--resume` |
| Spelunked into `@ctxr/fsm` directly for recovery | `--resume` is a documented top-level CLI mode |

## Test plan

- [x] `npm run validate:fsm` — 0 errors, 15 states.
- [x] `npm run lint` — 0 errors over 562 files.
- [x] `npm test` — 209/209 (was 199; +9 unit + 1 integration test).
- [x] Smoke `--start`: `brief.outputs_path` present + `<run_dir>/workers/scan_project-brief.json` matches stdout byte-for-byte.
- [x] Smoke `--continue` without `--outputs-file`: runner finds default path, advances cleanly.
- [x] Smoke `--resume`: re-emits same brief from disk, identical to `--start`'s emit.
- [ ] CI green.

## Files

```
modified:   SKILL.md                                       # outputs_path mandate; --resume Recovery section
modified:   scripts/run-review.mjs                         # 4 helpers + enricher wiring + --resume + --continue default
modified:   tests/integration/end-to-end-runner.test.js    # +outputs_path assertion +brief-on-disk assertion + --resume test
new:        tests/unit/brief-disk-persistence.test.js      # 9 unit cases for the path helpers + enricher + writeBriefToDisk
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)