### PR TITLE
feat(skill): embed worker.response_schema in dispatch prompt (closes #85)

### DIFF
--- a/scripts/lib/leaf-frontmatter.mjs
+++ b/scripts/lib/leaf-frontmatter.mjs
@@ -30,8 +30,17 @@ export function splitFrontmatter(text) {
   const openingMatch = text.match(/^---\r?\n/);
   if (!openingMatch) return null;
   const openingLen = openingMatch[0].length;
-  const closingMatch = text.slice(openingLen).match(/(\r?\n)---(\r?\n|$)/);
+  // Closing-fence regex allows an empty frontmatter block (`---\n---\n…`)
+  // by treating the leading newline as optional when the fence sits at
+  // the very start of the slice. The captured prefix-length is then 0
+  // and frontmatter slices to the empty string.
+  const remainder = text.slice(openingLen);
+  const closingMatch = remainder.match(/(^|\r?\n)---(\r?\n|$)/);
   if (!closingMatch) return null;
+  // closingMatch.index points at the start of the leading newline (or
+  // at 0 when the empty-frontmatter `^` alternative matched). Slicing
+  // up to that index drops the leading newline from the frontmatter
+  // value, which is what callers expect.
   const fmEnd = openingLen + closingMatch.index;
   const bodyStart = openingLen + closingMatch.index + closingMatch[0].length;
   return {

--- a/scripts/lib/worker-replay.mjs
+++ b/scripts/lib/worker-replay.mjs
@@ -107,7 +107,15 @@ function canonicalJson(value) {
 //   - repoRoot:        optional; only used to read the prompt body. When
 //                      omitted, only the path is hashed (back-compat with
 //                      callers that don't have repo-root context).
-export function computeHashKey({ state, promptTemplate, inputs, repoRoot }) {
+//   - responseSchema:  optional; the FSM-declared response_schema for
+//                      this state. Issue #85 made the schema part of
+//                      the worker-visible dispatch prompt, so a schema
+//                      tweak now changes the effective worker contract
+//                      even when prompt_body / inputs are unchanged. We
+//                      canonicalise it into the hash so old fixtures
+//                      recorded against a looser schema get a replay
+//                      miss when the schema tightens.
+export function computeHashKey({ state, promptTemplate, inputs, repoRoot, responseSchema }) {
   const h = createHash("sha256");
   h.update(String(state ?? ""));
   h.update("\u001f"); // unit-separator — unlikely to appear in any field
@@ -186,6 +194,15 @@ export function computeHashKey({ state, promptTemplate, inputs, repoRoot }) {
   h.update(promptBody);
   h.update("\u001f");
   h.update(canonicalJson(inputs ?? {}));
+  h.update("\u001f");
+  // Include the response_schema (canonicalised) so a schema tweak in
+  // the FSM yaml busts the hash even when the prompt body and inputs
+  // are byte-identical. Issue #85 made the schema part of the
+  // worker-visible dispatch prompt, so the effective contract now
+  // depends on it. `null` (legacy callers that don't pass it) hashes
+  // distinctly from the canonical-form of an empty object so we can
+  // tell back-compat callers from "I really meant {}".
+  h.update(canonicalJson(responseSchema ?? null));
   return h.digest("hex");
 }
 

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -29,8 +29,8 @@
 // handler emits a `fault` so callers can react uniformly.
 
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync, mkdtempSync, existsSync, rmSync, renameSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { readFileSync, writeFileSync, mkdtempSync, existsSync, rmSync, renameSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve, relative, sep } from "node:path";
 import { tmpdir, platform } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -213,15 +213,57 @@ export function enrichBriefWithSpecialistBodies(brief) {
   const pickedLeaves = inputs?.picked_leaves;
   if (!Array.isArray(pickedLeaves) || pickedLeaves.length === 0) return brief;
   const wikiRoot = resolve(REPO_ROOT, "reviewers.wiki");
+  // Realpath the wiki root once. We require every resolved leaf path
+  // to land INSIDE this realpath, so an LLM-supplied `leaf.path` can't
+  // walk out via `..` segments or symlinks (defense-in-depth — the
+  // trim worker is supposed to produce only valid leaf paths, but this
+  // helper reads the file directly so the boundary check is local).
+  // Fail closed: if the wiki root can't be realpathed, return the brief
+  // unenriched rather than reading arbitrary files. The orchestrator
+  // can still Read leaves from leaf.path itself.
+  let realWikiRoot;
+  try {
+    realWikiRoot = realpathSync(wikiRoot);
+  } catch {
+    return brief;
+  }
   const enrichedLeaves = pickedLeaves.map((leaf) => {
     if (!leaf || typeof leaf.path !== "string") return leaf;
+    // Apply the same leaf-shape guards as
+    // scripts/lib/trim-output-validator.mjs leafPathExists():
+    //   - must end in `.md`
+    //   - basename cannot be `index.md` (cluster summary, not a leaf)
+    //   - basename cannot start with `.` (dotfiles like `.gitignore`)
+    // The realpath boundary check below blocks paths outside the wiki,
+    // but `reviewers.wiki/index.md` and `reviewers.wiki/.gitignore`
+    // ARE inside the wiki — these guards stop a malformed brief from
+    // baking either into a specialist prompt.
+    if (!leaf.path.endsWith(".md")) return leaf;
+    const baseSeg = leaf.path.split(/[\\/]/).pop() ?? "";
+    if (!baseSeg || baseSeg === "index.md" || baseSeg.startsWith(".")) {
+      return leaf;
+    }
     // Try wiki-relative first (the canonical shape from tree_descend),
     // then repo-relative as a fallback (some upstream tooling carries the
     // longer prefix). Mirrors verify-coverage.mjs's resolution order.
     const candidates = [resolve(wikiRoot, leaf.path), resolve(REPO_ROOT, leaf.path)];
     for (const candidate of candidates) {
       try {
-        const text = readFileSync(candidate, "utf8");
+        // Realpath-then-boundary: if a candidate resolves to a path
+        // outside the wiki tree (via ../ segments or symlinks), refuse
+        // to read it. We allow either the canonical wiki-relative
+        // candidate OR a repo-relative candidate that ALSO realpaths
+        // into the wiki, since the wiki lives under the repo.
+        const realCandidate = realpathSync(candidate);
+        const rel = relative(realWikiRoot, realCandidate);
+        // The isAbsolute(rel) guard catches Windows cross-drive paths
+        // (`D:\...`) where path.relative returns an absolute string —
+        // those wouldn't start with `..` or `sep` and would otherwise
+        // pass the boundary check incorrectly.
+        if (rel === "" || rel.startsWith("..") || rel.startsWith(sep) || isAbsolute(rel)) {
+          continue; // outside the wiki — skip silently to next candidate
+        }
+        const text = readFileSync(realCandidate, "utf8");
         // PR for #83: parse the frontmatter so we can also surface
         // activation.file_globs as a structured field. The runner
         // (writeSpecialistPromptsToDisk → buildDispatchPromptText)
@@ -296,6 +338,12 @@ function computeFilteredDiff(baseSha, headSha, fileGlobs) {
     maxBuffer: 32 * 1024 * 1024,
   });
   if (result.error) {
+    // ENOBUFS: spawnSync's maxBuffer (32MB) was exceeded by the diff.
+    // Surface this distinctly so the placeholder names the cap rather
+    // than reading like a generic "spawn failed".
+    if (result.error.code === "ENOBUFS") {
+      return "(diff unavailable: filtered diff exceeded the 32 MB buffer cap; consider tightening the leaf's activation.file_globs[] to scope the diff)";
+    }
     return `(diff unavailable: git spawn failed: ${result.error.message ?? "unknown"})`;
   }
   // spawnSync sets `signal` (and leaves `status` null) when the child
@@ -512,8 +560,29 @@ export function buildDispatchPromptText(brief, opts = {}) {
     lines.push(`${name} = ${JSON.stringify(value, null, 2)}`);
     lines.push("");
   }
-  lines.push("--- OUTPUTS PATH ---");
-  lines.push(`Write your JSON response (matching the response_schema in your prompt above) to:`);
+  // PR for #85: embed the FSM-declared response_schema verbatim so the
+  // worker has a machine-readable contract for what to return. Before
+  // this, the prompt's tail said "matching the response_schema in your
+  // prompt above" but no schema was actually in the prompt — workers
+  // wrote blind and discovered the contract only at FSM commit time
+  // (post-hoc schema_violation faults). Some workers (project-scanner)
+  // shipped non-conforming shapes on first attempt under that regime.
+  const responseSchema = brief?.worker?.response_schema;
+  if (responseSchema && typeof responseSchema === "object") {
+    lines.push("--- RESPONSE SCHEMA (your JSON output must match this) ---");
+    lines.push(JSON.stringify(responseSchema, null, 2));
+    lines.push("");
+    lines.push("--- OUTPUTS PATH ---");
+    lines.push("Write your JSON response (matching the RESPONSE SCHEMA above) to:");
+  } else {
+    // Fallback: brief without a schema. Emit a generic OUTPUTS PATH
+    // preamble that doesn't mention any schema (since none exists for
+    // the worker to match). No state in the current FSM omits
+    // response_schema, but keeping the branch defensive avoids churn
+    // if a future state is intentionally schema-less.
+    lines.push("--- OUTPUTS PATH ---");
+    lines.push("Write your JSON response to:");
+  }
   lines.push(outputsPath);
   lines.push("");
   return lines.join("\n");
@@ -610,6 +679,12 @@ function hashKeyForBrief(brief, env) {
     // SHA in the hash — editing the prose without renaming the file
     // invalidates every recorded fixture for that worker.
     repoRoot: REPO_ROOT,
+    // PR for #85: the dispatch prompt now embeds the response_schema
+    // (so workers don't write blind). Including the schema in the
+    // hash means old fixtures get a replay-miss when the schema
+    // tightens — schema-related regressions can no longer be masked
+    // by stale cache hits.
+    responseSchema: brief?.worker?.response_schema ?? null,
   });
 }
 

--- a/tests/unit/dispatch-prompt-staging.test.js
+++ b/tests/unit/dispatch-prompt-staging.test.js
@@ -96,7 +96,63 @@ test("buildDispatchPromptText: standard worker — embeds prompt_body, INPUTS, O
   assert.match(text, /\/run\/dir\/workers\/scan_project-output\.json/);
 });
 
-test("buildDispatchPromptText: per-specialist — embeds leaf id/path/dimensions/file_globs/body, project_profile, changed_paths, pre-computed FILTERED DIFF section", () => {
+test("buildDispatchPromptText: standard worker — embeds RESPONSE SCHEMA when brief carries one (#85)", () => {
+  // Regression: previously the prompt's tail said "matching the
+  // response_schema in your prompt above" but no schema was embedded,
+  // and workers schema-faulted on first attempt. Lock the contract:
+  // when brief.worker.response_schema is present, the staged prompt
+  // emits a verbatim "--- RESPONSE SCHEMA ---" block.
+  const brief = {
+    has_worker: true,
+    state: "scan_project",
+    worker: {
+      role: "project-scanner",
+      inputs: ["args"],
+      prompt_body: "# Worker: project-scanner",
+      response_schema: {
+        type: "object",
+        required: ["project_profile"],
+        properties: {
+          project_profile: {
+            type: "object",
+            required: ["languages"],
+            properties: {
+              languages: { type: "array", items: { type: "string" } },
+            },
+          },
+        },
+      },
+    },
+    inputs: { args: {} },
+    outputs_path: "/run/dir/workers/scan_project-output.json",
+  };
+  const text = buildDispatchPromptText(brief);
+  assert.match(text, /--- RESPONSE SCHEMA \(your JSON output must match this\) ---/);
+  assert.match(text, /"required":\s*\[\s*"project_profile"/);
+  assert.match(text, /"languages":\s*\{\s*"type":\s*"array"/);
+  // OUTPUTS PATH preamble now references the schema section directly
+  // (replacing the misleading "in your prompt above" wording).
+  assert.match(text, /matching the RESPONSE SCHEMA above/);
+  assert.doesNotMatch(text, /response_schema in your prompt above/);
+});
+
+test("buildDispatchPromptText: standard worker — falls back gracefully when brief omits response_schema", () => {
+  // No FSM state today omits response_schema, but the prompt builder
+  // shouldn't break if a future state intentionally goes schema-less.
+  const brief = {
+    has_worker: true,
+    state: "future_schemaless_state",
+    worker: { role: "x", inputs: [], prompt_body: "# X" },
+    inputs: {},
+    outputs_path: "/run/dir/workers/future-output.json",
+  };
+  const text = buildDispatchPromptText(brief);
+  assert.match(text, /--- OUTPUTS PATH ---/);
+  assert.doesNotMatch(text, /--- RESPONSE SCHEMA/);
+  assert.match(text, /Write your JSON response to:/);
+});
+
+test("buildDispatchPromptText: per-specialist (no opts.filteredDiff) — emits FILTERED DIFF placeholder; checks leaf id/path/dimensions/file_globs/body, project_profile, changed_paths shape", () => {
   const brief = {
     has_worker: true,
     state: "dispatch_specialists",

--- a/tests/unit/leaf-frontmatter.test.js
+++ b/tests/unit/leaf-frontmatter.test.js
@@ -41,6 +41,18 @@ test("splitFrontmatter: CRLF input is parsed identically (Windows checkout)", ()
   assert.equal(out.body, "# Body\r\nsome content\r\n");
 });
 
+test("splitFrontmatter: parses empty frontmatter `---\\n---\\n<body>`", () => {
+  // Edge case: `---\n---\nbody` previously returned null because the
+  // closing-fence regex required a leading newline before the `---`.
+  // Empty frontmatter is valid markdown; the parser now accepts it
+  // and returns frontmatter="" with body intact.
+  const text = "---\n---\nbody starts here\n";
+  const out = splitFrontmatter(text);
+  assert.ok(out, "expected a result for empty frontmatter");
+  assert.equal(out.frontmatter, "");
+  assert.equal(out.body, "body starts here\n");
+});
+
 test("extractFileGlobs: returns empty when no activation block / no file_globs", () => {
   assert.deepEqual(extractFileGlobs(null), []);
   assert.deepEqual(extractFileGlobs(""), []);

--- a/tests/unit/worker-replay.test.js
+++ b/tests/unit/worker-replay.test.js
@@ -82,6 +82,52 @@ test("computeHashKey: same inputs → same hash; any input change → different 
   assert.notEqual(a, diffInputs);
 });
 
+test("computeHashKey: responseSchema participates in the hash (issue #85 cache-busting)", () => {
+  // Issue #85 made the FSM's response_schema part of the worker-visible
+  // dispatch prompt. The hash key must therefore include it: tightening
+  // a schema in the FSM yaml without renaming the prompt template
+  // would otherwise leave old fixtures replayable under the new
+  // contract, masking schema-related regressions.
+  const baseArgs = {
+    state: "scan_project",
+    promptTemplate: "fsm/workers/project-scanner.md",
+    inputs: { args: { foo: "bar" } },
+  };
+  const noSchema = computeHashKey(baseArgs);
+  const withSchemaA = computeHashKey({
+    ...baseArgs,
+    responseSchema: {
+      type: "object",
+      required: ["project_profile"],
+      properties: { project_profile: { type: "object" } },
+    },
+  });
+  const withSchemaB = computeHashKey({
+    ...baseArgs,
+    responseSchema: {
+      type: "object",
+      // Tightened: now also requires `changed_paths`.
+      required: ["project_profile", "changed_paths"],
+      properties: {
+        project_profile: { type: "object" },
+        changed_paths: { type: "array" },
+      },
+    },
+  });
+  assert.notEqual(noSchema, withSchemaA, "no schema vs. some schema must hash differently");
+  assert.notEqual(withSchemaA, withSchemaB, "tightening the schema must bust the hash");
+  // Same schema in different key order canonicalises to the same hash.
+  const withSchemaA2 = computeHashKey({
+    ...baseArgs,
+    responseSchema: {
+      properties: { project_profile: { type: "object" } },
+      required: ["project_profile"],
+      type: "object",
+    },
+  });
+  assert.equal(withSchemaA, withSchemaA2, "byte-different but logically-identical schemas must hash equal");
+});
+
 test("computeHashKey: same prompt body in CRLF and LF produces the same hash", async () => {
   // Without CRLF normalization, a Windows checkout (core.autocrlf=true)
   // would hash the same logical prompt to a different value than a


### PR DESCRIPTION
## Summary

- **Embed `brief.worker.response_schema` verbatim** (JSON.stringify, indent 2) under a new `--- RESPONSE SCHEMA (your JSON output must match this) ---` section in the standard-worker dispatch prompt, just before `--- OUTPUTS PATH ---`.
- **Update OUTPUTS PATH preamble** to reference the new schema section ("matching the RESPONSE SCHEMA above") instead of the misleading "in your prompt above" wording.
- **`computeHashKey` now incorporates `responseSchema`** (canonicalised) so a schema tweak in the FSM yaml busts cached fixtures.
- **Per-specialist branch unchanged in PR-2** — specialists have a fixed aggregation shape that lives in their prose RESPONSE CONTRACT, not the FSM yaml's `response_schema` slot.
- **Schema-less briefs fall back gracefully**.

## Stack note (please read before reviewing)

This PR is **stacked on #84** (`feat/per-leaf-filtered-diffs`, also open and awaiting human merge). Because GitHub CI only runs on PRs targeted at `main`, this PR's base is `main`, so the **diff visible here includes BOTH PR-1 and PR-2 commits**.

The reviewer (Copilot) repeatedly flags PR-1 changes (file_globs in per-leaf prompt, the `--- FILTERED DIFF ---` block, `enrichBriefWithSpecialistBodies` realpath checks, etc.) as if they were PR-2 changes. They are not — they belong to #84 and have their own review trail there.

What's actually new in this PR (relative to #84):
- `scripts/run-review.mjs` — `buildDispatchPromptText` standard-worker branch embeds the response_schema (~30 LOC).
- `scripts/lib/worker-replay.mjs` — `computeHashKey` accepts `responseSchema` and folds it into the digest.
- `scripts/lib/leaf-frontmatter.mjs` — empty-frontmatter parsing fix (round-2 review).
- Tests: `dispatch-prompt-staging.test.js` adds two cases for schema embedding + fallback; `worker-replay.test.js` adds a case for schema cache-busting; `leaf-frontmatter.test.js` adds the empty-frontmatter case.
- Several rounds of defense-in-depth on `enrichBriefWithSpecialistBodies` (realpath check, `isAbsolute(rel)` for Windows cross-drive, fail-closed when wikiRoot unrealpathable, basename guards for `.md` / `index.md` / dotfiles) — these address security concerns Copilot raised against the combined diff and apply equally to PR-1's surface.

## Why

Standard-worker dispatch prompts previously claimed "matching the response_schema in your prompt above" with no schema actually in the prompt. Workers wrote blind and discovered the contract only at FSM commit time. The most recent review run hit this: project-scanner returned `languages: [{name, percent}]` instead of the schema-required `languages: ["string"]`, faulting on first attempt. Manual recovery worked but is fragile and undocumented.

Closes #85.

## Test plan

- [x] `npm run validate:fsm` — 0 errors / 15 states
- [x] `npm run lint` — 0 errors over 562 files
- [x] `npm test` — 234 tests pass (was 230 at PR-1 tip; +4 cases for schema embedding, fallback, schema cache-busting, empty frontmatter)
- [x] Smoke-rendered prompt verified
- [x] Smoke-tested path traversal / absolute / index.md / dotfile / no-extension leaf.path inputs all return body_len=0; valid leaf works

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>