### PR TITLE
fix(deps): bump @ctxr/fsm for large-stdout fix (fsm#13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ctxr/fsm": "git+https://github.com/ctxr-dev/fsm.git#721d79e9ba93248c0e9ee0b94b328c15ac80bff7"
+        "@ctxr/fsm": "git+https://github.com/ctxr-dev/fsm.git#a4368c867f23d0bf6d61c58a0fb36e0dab4f11bd"
       },
       "devDependencies": {
         "gray-matter": "^4.0.3",
@@ -22,7 +22,8 @@
     },
     "node_modules/@ctxr/fsm": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/ctxr-dev/fsm.git#721d79e9ba93248c0e9ee0b94b328c15ac80bff7",
+      "resolved": "git+ssh://git@github.com/ctxr-dev/fsm.git#a4368c867f23d0bf6d61c58a0fb36e0dab4f11bd",
+      "integrity": "sha512-YHlBn15Mv3uFMxbNzOLlHGqJCi8uutVM8i7HeTV5Puj41SpfPs8JU3ASgS+lfFXDnf2Jg+d8MxpI6g9CIGzAfw==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prepublishOnly": "npm run validate:fsm && npm run lint && npm test"
   },
   "dependencies": {
-    "@ctxr/fsm": "git+https://github.com/ctxr-dev/fsm.git#721d79e9ba93248c0e9ee0b94b328c15ac80bff7"
+    "@ctxr/fsm": "git+https://github.com/ctxr-dev/fsm.git#a4368c867f23d0bf6d61c58a0fb36e0dab4f11bd"
   },
   "devDependencies": {
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary

Bumps \`@ctxr/fsm\` to \`a4368c8\` ([ctxr-dev/fsm#13](https://github.com/ctxr-dev/fsm/pull/13)). The upstream PR replaces all four FSM CLIs' \`emit()\` helpers with a shared \`emitJson()\` that loops \`fs.writeSync(1, …)\` until the full payload reaches the kernel — fixing the truncation-at-process.exit bug that bit every review of a non-trivial diff after PR #88 merged.

## Why

PR #88 made \`activated_leaves[*]\` carry 8 v2 frontmatter fields + \`file_globs[]\` per leaf. On real-corpus diffs that activates ~50-100 leaves, pushing the \`activate_leaves\` brief to ~120-260KB. Under the old emit shape, fsm-commit's stdout truncated at exactly 65534 bytes and the runner faulted with \"Unterminated string in JSON at position 65534\".

## Smoke test

- [x] \`npm run validate:fsm\` — 0 errors / 15 states
- [x] \`npm run lint\` — 0 errors over 562 files
- [x] \`npm test\` — 236 tests pass
- [x] End-to-end smoke: stubbed scan_project output, then \`--continue\` past activate_leaves. Result: tree_descend brief on disk is 120,990 bytes byte-complete; the runner cleanly emits \`awaiting_worker\` for tree_descend (where the previous run faulted).

## What changed

Only \`package.json\` and \`package-lock.json\`. No source changes — the fix is entirely upstream.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>