### PR TITLE
feat(skill): pre-dispatch coverage gate in trim-output-validator

### DIFF
--- a/fsm/workers/trim-candidates.md
+++ b/fsm/workers/trim-candidates.md
@@ -26,6 +26,8 @@ Coverage rule: every file in `changed_paths` must be covered by ≥ 2 picked lea
 
 If a file falls below 2-coverage, add the next-most-relevant rejected leaf with a "coverage rescue" justification and record it in `coverage_rescues`. **Do not** open leaf files — `file_globs[]` plus `focus` / `covers` from `stage_a_candidates[*]` is everything you need.
 
+**Hard pre-dispatch gate:** every file in `changed_paths` MUST be matched by at least ONE picked leaf's `activation.file_globs[]` OR appear explicitly in `coverage_rescues[*].file`. A leaf with empty / missing globs counts as broad credit (its specialist receives the full diff). The runner-side trim-output-validator will reject your output with a structured `changed_paths not covered ...` error if any path is left orphan; rescue the gap with a `coverage_rescues` entry rather than silently leaving the file uncovered.
+
 ## Output (JSON, schema-validated)
 
 ```json

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -184,16 +184,27 @@ function normalizeWikiPath(p) {
 }
 
 // Read a single leaf's `activation.file_globs[]` from disk. Returns:
-//   - { found: true, globs: [...] }  when the leaf carries an `activation.file_globs:` block
-//   - { found: true, globs: [] }     when the leaf carries an activation block but no globs
-//   - { found: false }               when the leaf is unreadable / missing / has no frontmatter
+//   - { found: true, globs: [...] }  when extractFileGlobs found a populated
+//                                    activation.file_globs[] block.
+//   - { found: true, globs: [] }     when extractFileGlobs returned [] —
+//                                    EITHER the leaf has no activation block
+//                                    at all, OR it has activation but no
+//                                    file_globs sub-block, OR the sub-block
+//                                    is explicitly empty. extractFileGlobs
+//                                    deliberately collapses these three
+//                                    cases (see leaf-frontmatter.mjs); the
+//                                    coverage-gate semantics are identical
+//                                    for all three (broad credit).
+//   - { found: false }               when the leaf is unreadable / missing /
+//                                    has no frontmatter fences at all.
 //
 // The {found, globs} shape lets callers distinguish "this leaf has empty
 // globs (broad credit)" from "we couldn't read this leaf at all". For the
 // pre-dispatch coverage gate, an unreadable leaf doesn't help cover any
 // file (we can't reason about what it would see), so it's treated as
-// no-credit. An empty-globs leaf gets broad credit — its specialist
-// receives the full diff per scripts/run-review.mjs:computeFilteredDiff.
+// no-credit. An empty-globs leaf — whatever the underlying authoring
+// shape — gets broad credit, because its specialist receives the full
+// diff per scripts/run-review.mjs:computeFilteredDiff.
 //
 // Cached per-process keyed by realpath of the wiki leaf to avoid repeat
 // frontmatter reads when the same trim output is validated multiple times

--- a/scripts/lib/trim-output-validator.mjs
+++ b/scripts/lib/trim-output-validator.mjs
@@ -19,8 +19,10 @@
 // engine's declarative `referential_integrity:` block subsumes this;
 // we migrate to the declarative form and delete the bespoke validator.
 //
-// Six violation classes (the original five from #13 plus a stage-A pair check
-// added in round 4 to close a subtle id/path-split fabrication path):
+// Seven violation classes (the original five from #13 plus a stage-A pair check
+// added in round 4 to close a subtle id/path-split fabrication path; class 7
+// added by the per-leaf-coverage-gate work to make sure no changed_path
+// reaches dispatch_specialists with zero specialists looking at it):
 //   1. picked_leaves[*].id        ∈ leaf ids in reviewers.wiki/
 //   2. picked_leaves[*].path      resolves to a real wiki file
 //   3. picked_leaves[*]           matches a stage_a_candidates entry with the
@@ -31,6 +33,14 @@
 //   4. rejected_leaves[*].id      ∈ stage_a_candidates ids
 //   5. coverage_rescues[*].file   ∈ changed_paths
 //   6. coverage_rescues[*].rescued_leaf ∈ rejected_leaves[*].id
+//   7. every changed_paths[*]     is matched by ≥1 picked_leaf — either via an
+//                                 `activation.file_globs[]` glob OR a leaf with
+//                                 no globs (broad credit; specialist receives
+//                                 the full diff) OR explicit listing in
+//                                 coverage_rescues[*].file. Closes the
+//                                 "orphan changed_path reaches dispatch with
+//                                 zero specialists" gap surfaced in the
+//                                 most recent end-to-end review.
 //
 // The validator is a pure function: same `(outputs, env, opts)` →
 // same `{ ok, errors[] }`. It does fs reads to enumerate the wiki when
@@ -41,6 +51,9 @@
 import { readdirSync, lstatSync, realpathSync, existsSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { splitFrontmatter, extractFileGlobs } from "./leaf-frontmatter.mjs";
+import { minimatch } from "./minimatch-shim.mjs";
 
 // Cache keyed by realpath of `<repoRoot>/reviewers.wiki`. A single-process
 // run that walks two different repos (tests, multi-repo tooling) gets a
@@ -168,6 +181,69 @@ function normalizeWikiPath(p) {
   let out = p.replace(/^\.\/+/, "");
   if (out.startsWith("reviewers.wiki/")) out = out.slice("reviewers.wiki/".length);
   return out;
+}
+
+// Read a single leaf's `activation.file_globs[]` from disk. Returns:
+//   - { found: true, globs: [...] }  when the leaf carries an `activation.file_globs:` block
+//   - { found: true, globs: [] }     when the leaf carries an activation block but no globs
+//   - { found: false }               when the leaf is unreadable / missing / has no frontmatter
+//
+// The {found, globs} shape lets callers distinguish "this leaf has empty
+// globs (broad credit)" from "we couldn't read this leaf at all". For the
+// pre-dispatch coverage gate, an unreadable leaf doesn't help cover any
+// file (we can't reason about what it would see), so it's treated as
+// no-credit. An empty-globs leaf gets broad credit — its specialist
+// receives the full diff per scripts/run-review.mjs:computeFilteredDiff.
+//
+// Cached per-process keyed by realpath of the wiki leaf to avoid repeat
+// frontmatter reads when the same trim output is validated multiple times
+// in one run (e.g., dry-run + commit).
+const _leafGlobsCache = new Map();
+function readLeafFileGlobs(repoRoot, leafPath) {
+  if (typeof leafPath !== "string" || leafPath.length === 0) return { found: false };
+  if (!leafPath.endsWith(".md")) return { found: false };
+  const base = leafPath.split(/[/\\]+/).pop();
+  if (!base || base === "index.md" || base.startsWith(".")) return { found: false };
+  const wikiRoot = resolve(repoRoot, "reviewers.wiki");
+  let realWiki;
+  try {
+    realWiki = realpathSync(wikiRoot);
+  } catch {
+    return { found: false };
+  }
+  let real = null;
+  for (const candidate of [resolve(wikiRoot, leafPath), resolve(repoRoot, leafPath)]) {
+    if (!existsSync(candidate)) continue;
+    let r;
+    try {
+      r = realpathSync(candidate);
+    } catch {
+      continue;
+    }
+    if (!isInside(realWiki, r)) continue;
+    real = r;
+    break;
+  }
+  if (real === null) return { found: false };
+  if (_leafGlobsCache.has(real)) return _leafGlobsCache.get(real);
+  let text;
+  try {
+    text = readFileSync(real, "utf8");
+  } catch {
+    const result = { found: false };
+    _leafGlobsCache.set(real, result);
+    return result;
+  }
+  const parsed = splitFrontmatter(text);
+  if (!parsed) {
+    const result = { found: false };
+    _leafGlobsCache.set(real, result);
+    return result;
+  }
+  const globs = extractFileGlobs(parsed.frontmatter);
+  const result = { found: true, globs };
+  _leafGlobsCache.set(real, result);
+  return result;
 }
 
 function looksLikeTrimOutput(outputs) {
@@ -354,6 +430,67 @@ export function validateTrimOutput(outputs, env, opts = {}) {
     if (!rejectedIds.has(rescue.rescued_leaf)) {
       errors.push(
         `coverage_rescues[].rescued_leaf "${rescue.rescued_leaf}" is not in rejected_leaves`,
+      );
+    }
+  }
+
+  // (7) Every changed_paths[*] is matched by ≥1 picked_leaf glob OR appears
+  //     in coverage_rescues[*].file. A leaf with no globs (broad credit)
+  //     covers everything because its specialist receives the full diff
+  //     per scripts/run-review.mjs:computeFilteredDiff. A leaf whose
+  //     frontmatter is unreadable does NOT count — we can't reason about
+  //     what its specialist would see, so treat as no-credit.
+  //
+  //     This closes the orphan-changed-path gap: under the previous five
+  //     checks, the trim worker could pick K leaves whose globs covered
+  //     only a subset of changed_paths and still pass validation. The
+  //     missed file would never appear in any specialist's filtered
+  //     diff; verify_coverage's post-dispatch check would surface it as
+  //     a coverage gap, but only after specialist tokens were spent.
+  //     Here we fail the trim output BEFORE dispatch.
+  const rescuedFiles = new Set(
+    coverageRescues
+      .map((r) => (r && typeof r.file === "string" ? r.file : null))
+      .filter((f) => f !== null),
+  );
+  // Build the broad-credit short-circuit ONCE: if any picked_leaf has
+  // empty globs (or a found-but-no-globs frontmatter), every changed_path
+  // is automatically covered and we skip the per-file loop entirely.
+  // This keeps the common case (one broad-purpose leaf among the picks)
+  // O(K) rather than O(K × len(changed_paths) × avg_globs_per_leaf).
+  let hasBroadCreditLeaf = false;
+  const leafGlobsByPath = new Map(); // leaf.path → string[] of globs
+  for (const leaf of pickedLeaves) {
+    if (!leaf || typeof leaf.path !== "string") continue;
+    const result = readLeafFileGlobs(repoRoot, leaf.path);
+    if (!result.found) continue; // unreadable: no credit
+    if (result.globs.length === 0) {
+      hasBroadCreditLeaf = true;
+      break;
+    }
+    leafGlobsByPath.set(leaf.path, result.globs);
+  }
+  if (!hasBroadCreditLeaf) {
+    const orphanFiles = [];
+    for (const file of (Array.isArray(env?.changed_paths) ? env.changed_paths : [])) {
+      if (rescuedFiles.has(file)) continue;
+      let covered = false;
+      for (const globs of leafGlobsByPath.values()) {
+        for (const glob of globs) {
+          if (minimatch(file, glob)) {
+            covered = true;
+            break;
+          }
+        }
+        if (covered) break;
+      }
+      if (!covered) orphanFiles.push(file);
+    }
+    if (orphanFiles.length > 0) {
+      errors.push(
+        `changed_paths not covered by any picked_leaf glob and not rescued: ` +
+          orphanFiles.map((f) => `"${f}"`).join(", ") +
+          ` — add a coverage_rescue for each, or pick a leaf whose activation.file_globs[] matches.`,
       );
     }
   }

--- a/tests/unit/trim-output-validator.test.js
+++ b/tests/unit/trim-output-validator.test.js
@@ -32,12 +32,19 @@ if (existsSync(NONEXISTENT_REPO_ROOT)) {
 // independent of the real corpus.
 let HERMETIC_REPO_ROOT;
 
-function writeLeaf(repoRoot, relPath, id) {
+function writeLeaf(repoRoot, relPath, id, fileGlobs) {
   const abs = join(repoRoot, "reviewers.wiki", relPath);
   mkdirSync(dirname(abs), { recursive: true });
+  let activation = "";
+  if (Array.isArray(fileGlobs)) {
+    const items = fileGlobs.length > 0
+      ? fileGlobs.map((g) => `    - "${g}"`).join("\n") + "\n"
+      : "";
+    activation = `activation:\n  file_globs:\n${items}`;
+  }
   writeFileSync(
     abs,
-    `---\nid: ${id}\ntype: leaf\n---\n\n# ${id}\n`,
+    `---\nid: ${id}\ntype: leaf\n${activation}---\n\n# ${id}\n`,
   );
 }
 
@@ -307,4 +314,168 @@ test("validateTrimOutput: missing fields on a trim output produce specific error
   assert.match(joined, /missing or not a string|does not resolve/);
   assert.match(joined, /missing string `file`/);
   assert.match(joined, /missing string `rescued_leaf`/);
+});
+
+// ─── Class 7: pre-dispatch coverage gate ───────────────────────────────
+//
+// Hermetic fixture for class 7: two leaves with explicit, non-overlapping
+// activation.file_globs[]. We pick from a stage-A set whose union of
+// globs covers the whole VALID_ENV.changed_paths set, then deviate the
+// picks to expose orphan files.
+
+let COVERAGE_REPO_ROOT;
+
+before(() => {
+  COVERAGE_REPO_ROOT = mkdtempSync(join(tmpdir(), "trim-coverage-"));
+  // Two real leaves under the coverage repo with disjoint globs:
+  //   ts-leaf  matches **/*.ts
+  //   util-leaf matches src/util/**
+  writeLeaf(COVERAGE_REPO_ROOT, "cluster-a/ts-leaf.md", "ts-leaf", ["**/*.ts"]);
+  writeLeaf(COVERAGE_REPO_ROOT, "cluster-a/util-leaf.md", "util-leaf", ["src/util/**"]);
+  // Third leaf with NO activation block at all (broad-credit case).
+  writeLeaf(COVERAGE_REPO_ROOT, "cluster-a/broad-leaf.md", "broad-leaf");
+  // Fourth with explicit empty file_globs (also broad-credit, distinct shape).
+  writeLeaf(COVERAGE_REPO_ROOT, "cluster-a/empty-globs-leaf.md", "empty-globs-leaf", []);
+});
+
+after(() => {
+  if (COVERAGE_REPO_ROOT) rmSync(COVERAGE_REPO_ROOT, { recursive: true, force: true });
+});
+
+const COVERAGE_STAGE_A = [
+  { id: "ts-leaf",          path: "cluster-a/ts-leaf.md",          activation_match: ["file_globs"] },
+  { id: "util-leaf",        path: "cluster-a/util-leaf.md",        activation_match: ["file_globs"] },
+  { id: "broad-leaf",       path: "cluster-a/broad-leaf.md",       activation_match: ["focus_only"] },
+  { id: "empty-globs-leaf", path: "cluster-a/empty-globs-leaf.md", activation_match: ["focus_only"] },
+];
+
+test("validateTrimOutput: class 7 — every changed_path covered by some leaf glob (passes)", () => {
+  // ts-leaf covers **/*.ts, util-leaf covers src/util/**. Together they
+  // cover both changed_paths.
+  const out = {
+    picked_leaves: [
+      { id: "ts-leaf", path: "cluster-a/ts-leaf.md", justification: "j", dimensions: ["correctness"] },
+      { id: "util-leaf", path: "cluster-a/util-leaf.md", justification: "j", dimensions: ["correctness"] },
+    ],
+    rejected_leaves: [],
+    coverage_rescues: [],
+  };
+  const env = {
+    stage_a_candidates: COVERAGE_STAGE_A,
+    changed_paths: ["src/api/auth.ts", "src/util/jwt.js"],
+  };
+  const result = validateTrimOutput(out, env, { repoRoot: COVERAGE_REPO_ROOT });
+  assert.deepEqual(result, { ok: true, errors: [] });
+});
+
+test("validateTrimOutput: class 7 — orphan changed_path with no rescue fails", () => {
+  // Pick only ts-leaf (covers **/*.ts). The .py changed_path is orphan.
+  const out = {
+    picked_leaves: [
+      { id: "ts-leaf", path: "cluster-a/ts-leaf.md", justification: "j", dimensions: ["correctness"] },
+    ],
+    rejected_leaves: [
+      { id: "util-leaf", reason: "irrelevant" },
+    ],
+    coverage_rescues: [],
+  };
+  const env = {
+    stage_a_candidates: COVERAGE_STAGE_A,
+    changed_paths: ["src/api/auth.ts", "scripts/migrate.py"],
+  };
+  const result = validateTrimOutput(out, env, { repoRoot: COVERAGE_REPO_ROOT });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.some(
+      (e) => e.includes("changed_paths not covered") && e.includes("scripts/migrate.py"),
+    ),
+    `expected an orphan-changed-path error naming scripts/migrate.py, got: ${result.errors.join("; ")}`,
+  );
+  // The covered path must NOT appear in the orphan list.
+  assert.ok(
+    !result.errors.some((e) => e.includes("changed_paths not covered") && e.includes("src/api/auth.ts")),
+  );
+});
+
+test("validateTrimOutput: class 7 — coverage_rescue closes the orphan gap", () => {
+  // Same orphan scenario, but the migrate.py path is in coverage_rescues.
+  const out = {
+    picked_leaves: [
+      { id: "ts-leaf", path: "cluster-a/ts-leaf.md", justification: "j", dimensions: ["correctness"] },
+    ],
+    rejected_leaves: [
+      { id: "util-leaf", reason: "irrelevant" },
+    ],
+    coverage_rescues: [
+      { file: "scripts/migrate.py", rescued_leaf: "util-leaf", reason: "fallback" },
+    ],
+  };
+  const env = {
+    stage_a_candidates: COVERAGE_STAGE_A,
+    changed_paths: ["src/api/auth.ts", "scripts/migrate.py"],
+  };
+  const result = validateTrimOutput(out, env, { repoRoot: COVERAGE_REPO_ROOT });
+  assert.deepEqual(result, { ok: true, errors: [] });
+});
+
+test("validateTrimOutput: class 7 — broad-credit leaf (no activation block) covers everything", () => {
+  // broad-leaf has no activation block in its frontmatter → broad credit.
+  // Even with globs that don't match, the broad-credit short-circuit makes
+  // every changed_path covered.
+  const out = {
+    picked_leaves: [
+      { id: "ts-leaf", path: "cluster-a/ts-leaf.md", justification: "j", dimensions: ["correctness"] },
+      { id: "broad-leaf", path: "cluster-a/broad-leaf.md", justification: "j", dimensions: ["correctness"] },
+    ],
+    rejected_leaves: [],
+    coverage_rescues: [],
+  };
+  const env = {
+    stage_a_candidates: COVERAGE_STAGE_A,
+    changed_paths: ["src/api/auth.ts", "scripts/migrate.py"],
+  };
+  const result = validateTrimOutput(out, env, { repoRoot: COVERAGE_REPO_ROOT });
+  assert.deepEqual(result, { ok: true, errors: [] });
+});
+
+test("validateTrimOutput: class 7 — broad-credit leaf with empty file_globs[] also covers everything", () => {
+  // empty-globs-leaf has activation: file_globs: [] explicitly. The
+  // computeFilteredDiff fallback gives that specialist the full diff,
+  // so for coverage purposes it credits every changed_path.
+  const out = {
+    picked_leaves: [
+      { id: "empty-globs-leaf", path: "cluster-a/empty-globs-leaf.md", justification: "j", dimensions: ["correctness"] },
+    ],
+    rejected_leaves: [],
+    coverage_rescues: [],
+  };
+  const env = {
+    stage_a_candidates: COVERAGE_STAGE_A,
+    changed_paths: ["any/path/here.xyz", "another/file.unknown"],
+  };
+  const result = validateTrimOutput(out, env, { repoRoot: COVERAGE_REPO_ROOT });
+  assert.deepEqual(result, { ok: true, errors: [] });
+});
+
+test("validateTrimOutput: class 7 — multiple orphans listed in one error", () => {
+  // No picked leaves cover anything; no rescues. All N changed_paths
+  // surface in the same error string.
+  const out = {
+    picked_leaves: [
+      { id: "ts-leaf", path: "cluster-a/ts-leaf.md", justification: "j", dimensions: ["correctness"] },
+    ],
+    rejected_leaves: [],
+    coverage_rescues: [],
+  };
+  const env = {
+    stage_a_candidates: COVERAGE_STAGE_A,
+    changed_paths: ["a.py", "b.rb", "c.go"],
+  };
+  const result = validateTrimOutput(out, env, { repoRoot: COVERAGE_REPO_ROOT });
+  assert.equal(result.ok, false);
+  const orphanErr = result.errors.find((e) => e.includes("changed_paths not covered"));
+  assert.ok(orphanErr, `expected an orphan-changed-path error, got: ${result.errors.join("; ")}`);
+  assert.ok(orphanErr.includes("a.py"));
+  assert.ok(orphanErr.includes("b.rb"));
+  assert.ok(orphanErr.includes("c.go"));
 });


### PR DESCRIPTION
## Summary

Adds a 7th referential-integrity check to \`validateTrimOutput\`: every \`changed_path\` must be matched by ≥1 \`picked_leaf\`'s \`activation.file_globs[]\` OR appear explicitly in \`coverage_rescues[*].file\`.

## Why

The orchestrator's most recent end-to-end review surfaced this gap: the trim worker could pick K leaves whose globs covered only a subset of \`changed_paths\` and still pass validation. The missed file would never appear in any specialist's filtered diff; \`verify_coverage\` would only surface it post-dispatch after specialist tokens were spent. This PR fails the trim output BEFORE dispatch, with a structured error naming the orphan files.

## Implementation

- New \`readLeafFileGlobs(repoRoot, leafPath)\` helper. Resolves a leaf path against the wiki, parses its frontmatter via the shared \`scripts/lib/leaf-frontmatter.mjs\`, returns \`{found:true, globs:[]}\` for activation-less leaves (broad credit — specialist receives the full diff via \`computeFilteredDiff\`'s fallback) and \`{found:false}\` for unreadable leaves (no credit). Cached per-process.
- Class-7 check short-circuits on the first broad-credit picked leaf (empty / missing globs). Otherwise iterates each \`changed_path\` against the union of picked_leaves' globs using \`minimatch\`; surfaces all orphan paths in one structured error.
- \`trim-candidates.md\` prompt: new "Hard pre-dispatch gate" paragraph documents the new validator behavior.

## Test plan

- [x] \`npm run validate:fsm\` — 0 errors / 15 states
- [x] \`npm run lint\` — 0 errors over 562 files
- [x] \`npm test\` — 242 tests pass (was 236, +6 new cases for class 7)
- [x] New cases: pass with disjoint-glob coverage, fail on orphan, rescue closes gap, broad-credit via no-activation, broad-credit via empty globs, multi-orphan single error

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>