### PR TITLE
review: address round-5 minor findings + readManifest EISDIR robustness fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ This project's release history lives primarily as annotated git tags
 `main`. Each release commit carries the change summary in its body
 and on the corresponding GitHub Release.
 
-This file lists the user-facing changes per version. For the full
-diff, see the linked PR and tag on GitHub.
+This file lists the user-facing changes per version, formatted per
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+For the full diff, see the linked PR and tag on GitHub.
 
-## Unreleased
+## [Unreleased]
+
+### Changed
 
 - **Hardened `--continue` error handling for `dispatch_specialists`.**
   Replaced the silent `try { JSON.parse(brief) } catch { brief = null }`
@@ -20,6 +24,9 @@ diff, see the linked PR and tag on GitHub.
   missing `current_state`. Operators no longer see misleading "outputs
   file not found" errors when the underlying cause is brief or
   manifest corruption.
+
+### Added
+
 - **New `--- FORBIDDEN PATHS ---` section in dispatch prompts.** The
   runner now injects an explicit prohibition on `/tmp/*` writes (and
   any path outside the run-dir) into every staged dispatch prompt and
@@ -36,7 +43,7 @@ diff, see the linked PR and tag on GitHub.
     output (kept under the documented ~200-token bound).
   Both are kept in lockstep on load-bearing tokens by a unit test.
 
-## v2.2.1 (#98)
+## [2.2.1] - 2026-05-02
 
 Release commit: [`797603f`](../../commit/797603f) — see PR #97 for
 the underlying fix (forbid `/tmp` writes by dispatched workers; harden
@@ -47,3 +54,6 @@ the underlying fix (forbid `/tmp` writes by dispatched workers; harden
 For releases v2.2.0 and earlier, see the git tags and corresponding
 release commits on `main`. Each `release: vX.Y.Z (#N)` commit links
 to the PR whose body documents the change set.
+
+[Unreleased]: https://github.com/ctxr-dev/skill-code-review/compare/v2.2.1...HEAD
+[2.2.1]: https://github.com/ctxr-dev/skill-code-review/compare/v2.2.0...v2.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+This project's release history lives primarily as annotated git tags
+(`v<MAJOR>.<MINOR>.<PATCH>`) and squash-merged release commits on
+`main`. Each release commit carries the change summary in its body
+and on the corresponding GitHub Release.
+
+This file lists the user-facing changes per version. For the full
+diff, see the linked PR and tag on GitHub.
+
+## Unreleased
+
+- **Hardened `--continue` error handling for `dispatch_specialists`.**
+  Replaced the silent `try { JSON.parse(brief) } catch { brief = null }`
+  swallow with a structured `fail()` that names the brief path and the
+  parse error, mirroring the contract `--print-batch-envelope` already
+  uses on the same brief. Replaced the silent
+  `manifest?.current_state ?? null` degradation in the explicit
+  `--outputs-file` branch with hard-fails on missing manifest and
+  missing `current_state`. Operators no longer see misleading "outputs
+  file not found" errors when the underlying cause is brief or
+  manifest corruption.
+- **New `--- FORBIDDEN PATHS ---` section in dispatch prompts.** The
+  runner now injects an explicit prohibition on `/tmp/*` writes (and
+  any path outside the run-dir) into every staged dispatch prompt and
+  every shim emitted by `--print-agent-shim-prompt`. Closes a
+  real-world regression where dispatched sub-Agents wrote scratch
+  files (`/tmp/tree-descend/build.js`,
+  `/tmp/worker-out-*.json`) — the skill's SKILL.md prohibition applied
+  only to the orchestrator, not to dispatched workers.
+- **New exports from `scripts/run-review.mjs`.** Two string constants
+  describe the FORBIDDEN PATHS contract:
+  - `FORBIDDEN_PATHS_NOTICE_FULL` — long-form rationale embedded in
+    dispatch prompts.
+  - `FORBIDDEN_PATHS_NOTICE_SHIM` — compact one-liner used in shim
+    output (kept under the documented ~200-token bound).
+  Both are kept in lockstep on load-bearing tokens by a unit test.
+
+## v2.2.1 (#98)
+
+Release commit: [`797603f`](../../commit/797603f) — see PR #97 for
+the underlying fix (forbid `/tmp` writes by dispatched workers; harden
+`--continue` error handling).
+
+## Older
+
+For releases v2.2.0 and earlier, see the git tags and corresponding
+release commits on `main`. Each `release: vX.Y.Z (#N)` commit links
+to the PR whose body documents the change set.

--- a/scripts/run-review.mjs
+++ b/scripts/run-review.mjs
@@ -414,18 +414,28 @@ function computeFilteredDiff(baseSha, headSha, fileGlobs) {
 const DEFAULT_SHARD_THRESHOLD = 256 * 1024;
 
 // Single source of truth for the FORBIDDEN PATHS notice that every
-// dispatched worker / specialist Agent must see. Real-world regression:
-// dispatched Agents have been observed writing scratch files like
-// `/tmp/tree-descend/build.js`, `/tmp/trim-prompt.md`, and
-// `/tmp/worker-out-*.json` despite the skill's SKILL.md forbidding it
-// for the orchestrator. The prohibition has to be IN the dispatch
-// prompt the Agent reads (the skill's own SKILL.md is not visible to
-// dispatched sub-Agents). This constant is referenced from
-// buildDispatchPromptText (both the per-specialist branch and the
-// standard-worker branch) AND from buildShimText so the wording stays
-// byte-identical across every emission site — drift between copies
-// silently weakens the contract for whichever worker has the stale
-// copy.
+// dispatched worker / specialist Agent must see. Regression history:
+// dispatched Agents were observed writing scratch files like
+// `/tmp/tree-descend/build.js` and `/tmp/worker-out-*.json` despite
+// the skill's SKILL.md forbidding it; the skill's SKILL.md is not
+// visible to dispatched sub-Agents, so the prohibition has to be IN
+// the dispatch prompt the Agent reads.
+//
+// Both notice variants are exported so tests can assert they share
+// load-bearing tokens (`tests/unit/dispatch-prompt-staging.test.js`
+// — guards against silent drift between the long and short forms).
+
+/**
+ * Long-form FORBIDDEN PATHS rationale embedded in dispatch prompts
+ * (one copy per prompt, in either the standard-worker `--- FORBIDDEN
+ * PATHS ---` section or the per-specialist `--- RESPONSE CONTRACT ---`
+ * block). Audience: the dispatched worker / specialist Agent.
+ *
+ * The wording must include the load-bearing tokens enumerated by
+ * `FORBIDDEN_PATHS_LOAD_BEARING_TOKENS` in the unit test suite.
+ *
+ * @type {string}
+ */
 export const FORBIDDEN_PATHS_NOTICE_FULL =
   "NEVER write to /tmp/* or any path outside the run-dir. This includes " +
   "scratch files (build.js, leaves.json, ad-hoc node -e scripts, etc.). " +
@@ -435,14 +445,19 @@ export const FORBIDDEN_PATHS_NOTICE_FULL =
   "need scratch space, use the same workers/ directory that holds your " +
   "dispatch prompt.";
 
-// Compact one-liner derived from FORBIDDEN_PATHS_NOTICE_FULL for the shim
-// prompt — the shim has a documented ~200-token bound, so it gets a
-// short-form pointer that names the rule and the canonical location of
-// the full rationale (the on-disk dispatch prompt the shim references).
-// Both constants are exported so tests can assert they share the
-// load-bearing tokens (NEVER write to /tmp, only allowed write target
-// is the output path) — guards against silent semantic drift between
-// the long and short forms.
+/**
+ * Compact form of the FORBIDDEN PATHS notice used in the
+ * `--print-agent-shim-prompt` output. Audience: the dispatched
+ * specialist Agent (which reads this inline before opening the staged
+ * per-leaf prompt). The shim has a documented ~200-token bound, so
+ * this form drops the rationale prose and keeps only the rule and the
+ * canonical write target.
+ *
+ * Must share the load-bearing tokens with FORBIDDEN_PATHS_NOTICE_FULL
+ * AND must be strictly shorter (audience-inversion guard).
+ *
+ * @type {string}
+ */
 export const FORBIDDEN_PATHS_NOTICE_SHIM =
   "FORBIDDEN PATHS: NEVER write to /tmp/* or any path outside the run-dir. " +
   "The ONLY allowed write target is the output path above. " +
@@ -2448,9 +2463,25 @@ async function main() {
     // --outputs-file in the common case.
     let outputsFile = args["outputs-file"];
     let currentState = null;
-    if (outputsFile === undefined) {
+    // Helper: read the manifest for this run-id, routing any I/O
+    // exception (e.g. EISDIR when manifest.json is a directory, or
+    // EACCES on a permissions-stripped run-dir) through a structured
+    // fail() instead of leaking as "unhandled error: <stack>". Both
+    // --continue branches below need this guard; centralising
+    // ensures both surface corruption with the same diagnostic shape.
+    const safeReadManifest = () => {
       const storageRoot = resolveStorageRoot();
-      const manifest = readManifest(runId, { storageRoot });
+      try {
+        return readManifest(runId, { storageRoot });
+      } catch (err) {
+        fail(
+          `--continue: failed to read manifest for run-id "${runId}": ${err.message}. The run-dir may be corrupted (manifest.json missing, unreadable, or replaced by a directory). Inspect the run-dir and retry.`,
+          { run_id: runId },
+        );
+      }
+    };
+    if (outputsFile === undefined) {
+      const manifest = safeReadManifest();
       if (!manifest) {
         fail(
           `--continue: no manifest found for run-id "${runId}"; cannot resolve default --outputs-file. Run --start first, or pass --outputs-file <path> explicitly.`,
@@ -2479,8 +2510,7 @@ async function main() {
       // way — silently nulling currentState here would degrade an
       // explicit-path corruption signal into a misleading "outputs
       // file not found" downstream.
-      const storageRoot = resolveStorageRoot();
-      const manifest = readManifest(runId, { storageRoot });
+      const manifest = safeReadManifest();
       if (!manifest) {
         fail(
           `--continue: no manifest found for run-id "${runId}". Run --start first, or check that the run-id is correct.`,

--- a/tests/integration/end-to-end-runner.test.js
+++ b/tests/integration/end-to-end-runner.test.js
@@ -14,6 +14,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1344,24 +1345,30 @@ function stripManifestCurrentState(manifestPath) {
 
 // Generates a sentinel run-id whose corresponding manifest is
 // guaranteed not to exist on disk. Suffix is derived from BOTH
-// process.pid (process-unique) AND a per-call counter (call-unique
-// within a process), so concurrent test files with the same pid AND
-// repeated calls within one file both stay collision-free.
+// process.pid (process-unique) AND a stable hash of t.name
+// (test-unique within a process), so concurrent test files with the
+// same pid AND multiple sentinel-using tests within one file both
+// stay collision-free without any module-level mutable state.
 // Round-5 review flagged the pid-only version as fragile under any
-// future --test-concurrency > 1 enablement.
+// future --test-concurrency > 1 enablement; round-6 review flagged
+// a previous mutable-counter version as cross-test coupling.
 //
 // Asserts nonexistence before returning so the test fails fast if
 // the sentinel ever collides with a real run-dir.
-let _sentinelCallCounter = 0;
-function freshNonexistentRunId() {
-  _sentinelCallCounter += 1;
-  // 7 hex chars total: 4 from pid + 3 from call counter, both
-  // wrapped to fit in their fields. Uniqueness held against
-  // 65536 × 4096 = 256M (pid, counter) pairs per process, more
-  // than enough for any conceivable test invocation pattern.
+function freshNonexistentRunId(t) {
+  assert.ok(
+    t && typeof t.name === "string" && t.name.length > 0,
+    "freshNonexistentRunId requires the test context (t) for stable per-test suffix derivation",
+  );
+  // 7 hex chars total: 4 from pid + 3 from a stable hash of t.name.
+  // Reproducible across runs of the same test, unique across tests
+  // and processes. No module-level mutable state.
   const pidNibbles = (process.pid & 0xFFFF).toString(16).padStart(4, "0");
-  const counterNibbles = (_sentinelCallCounter & 0xFFF).toString(16).padStart(3, "0");
-  const runId = `${SENTINEL_RUN_ID_PREFIX}${pidNibbles}${counterNibbles}`;
+  const nameNibbles = createHash("sha256")
+    .update(t.name)
+    .digest("hex")
+    .slice(0, 3);
+  const runId = `${SENTINEL_RUN_ID_PREFIX}${pidNibbles}${nameNibbles}`;
   const settings = resolveSettings({ fsmName: "code-reviewer" }, REPO_ROOT);
   const storageRoot = resolve(REPO_ROOT, settings.storageRoot);
   const manifestPath = join(runDirPath(runId, { storageRoot }), "manifest.json");
@@ -1415,7 +1422,7 @@ test("--continue: dispatch_specialists brief unparseable JSON hard-fails with st
   });
 });
 
-test("--continue --outputs-file <path>: explicit-path branch hard-fails on missing manifest (no silent null)", () => {
+test("--continue --outputs-file <path>: explicit-path branch hard-fails on missing manifest (no silent null)", (t) => {
   // Closes the silent-degradation review finding: the explicit
   // --outputs-file branch previously did `manifest?.current_state ??
   // null`, which collapsed missing-manifest into the same path as
@@ -1426,7 +1433,7 @@ test("--continue --outputs-file <path>: explicit-path branch hard-fails on missi
 
   // Arrange: a sentinel run-id that passes the validator regex but
   // has no manifest on disk (asserted by freshNonexistentRunId).
-  const fakeRunId = freshNonexistentRunId();
+  const fakeRunId = freshNonexistentRunId(t);
 
   // Act + Assert: hard-fail with "no manifest found" + run-id.
   assertContinueHardFails(fakeRunId, ["--outputs-file", "/nonexistent/x.json"], {
@@ -1498,14 +1505,52 @@ test("--continue: manifest path is a directory (not a file) — runner exits wit
   // We don't pin the exact error message wording (the runner's
   // EISDIR / ENOTFILE / "is a directory" surfaces vary by Node
   // version); we only require: non-zero exit, JSON-parseable
-  // stdout, and SOME message that mentions the run-id or the
-  // manifest path so the operator can diagnose.
+  // stdout, and SOME EISDIR/manifest-shape token so the regression
+  // is genuinely scoped to "runner couldn't read manifest as a
+  // file". Excludes "run-id" — that token leaks into virtually
+  // every fail() the runner emits and would weaken the regression
+  // intent (any unrelated fail-fast path could match).
+  //
+  // The structured payload's run_id field is pinned in
+  // extraAssertions instead, locking down that the
+  // manifest-corruption fail() carries the operator-actionable
+  // run-id (matches the contract on the parallel hard-fail tests
+  // above).
   assertContinueHardFails(runId, [], {
-    messageRegex: /(manifest|directory|EISDIR|ENOTFILE|run-id)/i,
+    messageRegex: /(manifest|directory|EISDIR|ENOTFILE)/i,
     extraAssertions: (payload) => {
-      assert.ok(typeof payload.message === "string" && payload.message.length > 0,
-        "fail() payload must carry a non-empty message",
-      );
+      assert.equal(payload.run_id, runId, "structured error must carry the run-id");
+    },
+  });
+});
+
+test("--continue --outputs-file <path>: manifest path is a directory — explicit-path branch also hard-fails (no SIGTERM)", (t) => {
+  // Parallel regression to the implicit-branch test above: the
+  // explicit --outputs-file branch routes through the same
+  // safeReadManifest() helper at scripts/run-review.mjs, so the
+  // EISDIR-as-directory hostile shape must surface as a structured
+  // fail() through this code path too. Without this, a future
+  // refactor that splits the two branches' manifest reads could
+  // silently regress one of them and the test suite would only
+  // catch it via the implicit branch.
+
+  // Arrange: fresh run, then replace the manifest file with a
+  // directory of the same name.
+  const { runId, manifestPath } = makeFreshRunForContinueTest(
+    t,
+    "7777777777777777777777777777777777777777",
+    "8888888888888888888888888888888888888888",
+  );
+  rmSync(manifestPath, { force: true });
+  mkdirSync(manifestPath, { recursive: true });
+
+  // Act + Assert: --continue --outputs-file <path> must produce a
+  // structured EISDIR/manifest-shape error, not a SIGTERM. Same
+  // contract as the implicit-branch test.
+  assertContinueHardFails(runId, ["--outputs-file", "/nonexistent/x.json"], {
+    messageRegex: /(manifest|directory|EISDIR|ENOTFILE)/i,
+    extraAssertions: (payload) => {
+      assert.equal(payload.run_id, runId, "structured error must carry the run-id");
     },
   });
 });

--- a/tests/integration/end-to-end-runner.test.js
+++ b/tests/integration/end-to-end-runner.test.js
@@ -14,8 +14,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { randomBytes } from "node:crypto";
-import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -1254,14 +1253,33 @@ function makeFreshRunForContinueTest(t, baseSha, headSha) {
   return { runId, runDir, workersDir, manifestPath };
 }
 
+// Pure parse helper used by assertContinueHardFails. Splits "spawn +
+// stdout/stderr capture" from "parse the stdout as structured JSON" so
+// the parsed result can be bound with `const` at the call site (no
+// `let payload; try { ... }` shape) and so a non-JSON stdout surfaces
+// as a single deterministic failure message naming the diagnostic
+// channel — review round 5's "let payload could be const" +
+// "assertions inside conditional branch" findings.
+function parseStdoutOrFail(stdout, stderr, label) {
+  try {
+    return JSON.parse(stdout);
+  } catch (err) {
+    assert.fail(
+      `${label}: expected structured JSON on stdout, got JSON.parse error "${err.message}".\nstdout: ${stdout}\nstderr: ${stderr}`,
+    );
+  }
+}
+
 // Shared assertion helper: spawn `--continue ...` (with optional extra
 // args), assert hard-fail (non-zero exit, parseable stdout JSON, no
 // leaked stack-frame paths, no misleading "outputs file not found"
 // fallthrough), then run the caller's regex against payload.message.
-// Closes the round-1 DRY finding (two new --continue hard-fail tests
-// shared spawn-and-assert scaffolding) and the round-1 negative-
-// assertions finding (every hard-fail test now consistently asserts
-// no stack-frame leak and no misleading-fallthrough leak).
+//
+// `extraContinueArgs` is a flat string[] of CLI tokens appended after
+// `--continue --run-id <id>`. Pass [] for the implicit-outputs-file
+// path; pass `["--outputs-file", "/path"]` to exercise the explicit
+// branch. Each element is fed to spawnSync's argv verbatim — no
+// shell quoting required.
 function assertContinueHardFails(runId, extraContinueArgs, { messageRegex, extraAssertions }) {
   const cont = spawnSync(
     process.execPath,
@@ -1269,18 +1287,11 @@ function assertContinueHardFails(runId, extraContinueArgs, { messageRegex, extra
     { encoding: "utf8", cwd: REPO_ROOT, timeout: CONTINUE_TEST_TIMEOUT_MS },
   );
   assert.notEqual(cont.status, 0, `--continue ${extraContinueArgs.join(" ")} must hard-fail; stdout=${cont.stdout}`);
-  // Guard the JSON.parse — under SIGTERM (timeout breach) or a runner
-  // crash we'd see non-JSON stdout, and a bare JSON.parse throw would
-  // hide the real failure mode. Re-throw with stdout + stderr in the
-  // failure message so CI logs surface the actual problem.
-  let payload;
-  try {
-    payload = JSON.parse(cont.stdout);
-  } catch (err) {
-    assert.fail(
-      `--continue ${extraContinueArgs.join(" ")}: expected structured JSON on stdout, got JSON.parse error "${err.message}".\nstdout: ${cont.stdout}\nstderr: ${cont.stderr}`,
-    );
-  }
+  const payload = parseStdoutOrFail(
+    cont.stdout,
+    cont.stderr,
+    `--continue ${extraContinueArgs.join(" ")}`,
+  );
   assert.match(payload.message, messageRegex);
   // The two negative assertions every hard-fail test must lock down:
   // no stack-frame leak (we'd be in fail()-the-stack territory) and
@@ -1299,7 +1310,9 @@ function assertContinueHardFails(runId, extraContinueArgs, { messageRegex, extra
 // shape, which is acceptable here because that shape is part of the
 // runner's public on-disk contract (assert-fresh-run.mjs and the FSM
 // engine both depend on `current_state`). Centralising the mutation
-// makes that coupling explicit + greppable.
+// makes that coupling explicit + greppable. Round-5 review flagged
+// the in-place mutation here; switched to spread to produce a fresh
+// object before write-back.
 function setManifestCurrentState(manifestPath, state) {
   const realManifest = JSON.parse(readFileSync(manifestPath, "utf8"));
   // Fail-fast precondition: the manifest must be a non-null object.
@@ -1310,22 +1323,45 @@ function setManifestCurrentState(manifestPath, state) {
     realManifest && typeof realManifest === "object" && !Array.isArray(realManifest),
     `manifest at ${manifestPath} is not an object; cannot set current_state on shape ${typeof realManifest}`,
   );
-  realManifest.current_state = state;
-  writeFileSync(manifestPath, JSON.stringify(realManifest));
+  writeFileSync(manifestPath, JSON.stringify({ ...realManifest, current_state: state }));
 }
 
-// Generates a deterministic-but-process-unique sentinel run-id whose
-// corresponding manifest is guaranteed not to exist on disk. Earlier
-// versions used randomBytes for the suffix, which made test failures
-// non-reproducible (the random value vanished after the run); this
-// version derives the suffix from process.pid (hex-padded to the
-// canonical 7 chars) so a failing test can be replayed under the same
-// pid by re-running without --test-concurrency. Asserts nonexistence
-// before returning so the test fails fast if the sentinel ever
-// collides with a real run-dir.
+// Manifest-state stripping helper, used to exercise the "manifest
+// exists but lacks current_state" branch. Round-5 review flagged the
+// previous in-place `delete realManifest.current_state` as a mutability
+// smell; rest-destructuring produces a stripped copy without
+// touching the parsed object.
+function stripManifestCurrentState(manifestPath) {
+  const realManifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  assert.ok(
+    realManifest && typeof realManifest === "object" && !Array.isArray(realManifest),
+    `manifest at ${manifestPath} is not an object; cannot strip current_state`,
+  );
+  // eslint-disable-next-line no-unused-vars
+  const { current_state: _stripped, ...rest } = realManifest;
+  writeFileSync(manifestPath, JSON.stringify(rest));
+}
+
+// Generates a sentinel run-id whose corresponding manifest is
+// guaranteed not to exist on disk. Suffix is derived from BOTH
+// process.pid (process-unique) AND a per-call counter (call-unique
+// within a process), so concurrent test files with the same pid AND
+// repeated calls within one file both stay collision-free.
+// Round-5 review flagged the pid-only version as fragile under any
+// future --test-concurrency > 1 enablement.
+//
+// Asserts nonexistence before returning so the test fails fast if
+// the sentinel ever collides with a real run-dir.
+let _sentinelCallCounter = 0;
 function freshNonexistentRunId() {
-  const suffix = process.pid.toString(16).padStart(7, "0").slice(-7);
-  const runId = `${SENTINEL_RUN_ID_PREFIX}${suffix}`;
+  _sentinelCallCounter += 1;
+  // 7 hex chars total: 4 from pid + 3 from call counter, both
+  // wrapped to fit in their fields. Uniqueness held against
+  // 65536 × 4096 = 256M (pid, counter) pairs per process, more
+  // than enough for any conceivable test invocation pattern.
+  const pidNibbles = (process.pid & 0xFFFF).toString(16).padStart(4, "0");
+  const counterNibbles = (_sentinelCallCounter & 0xFFF).toString(16).padStart(3, "0");
+  const runId = `${SENTINEL_RUN_ID_PREFIX}${pidNibbles}${counterNibbles}`;
   const settings = resolveSettings({ fsmName: "code-reviewer" }, REPO_ROOT);
   const storageRoot = resolve(REPO_ROOT, settings.storageRoot);
   const manifestPath = join(runDirPath(runId, { storageRoot }), "manifest.json");
@@ -1337,7 +1373,7 @@ function freshNonexistentRunId() {
 }
 
 
-test("--continue: dispatch_specialists brief unparseable JSON hard-fails with structured error (no silent swallow)", (t) => {
+test("--continue: dispatch_specialists brief unparseable JSON hard-fails with structured error", (t) => {
   // Closes the silent-swallow review finding: the previous
   // `try { JSON.parse(...) } catch { brief = null; }` masked
   // brief corruption and let --continue fall through to a
@@ -1416,15 +1452,60 @@ test("--continue --outputs-file <path>: explicit-path branch hard-fails when man
     "1111111111111111111111111111111111111111",
     "2222222222222222222222222222222222222222",
   );
-  const realManifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-  delete realManifest.current_state;
-  writeFileSync(manifestPath, JSON.stringify(realManifest));
+  stripManifestCurrentState(manifestPath);
 
   // Act + Assert: hard-fail naming the manifest-corrupted condition.
   assertContinueHardFails(runId, ["--outputs-file", "/nonexistent/x.json"], {
     messageRegex: /manifest has no current_state/,
     extraAssertions: (payload) => {
       assert.ok(payload.message.includes(runId), "error must name the run-id");
+    },
+  });
+});
+
+test("--continue: manifest path is a directory (not a file) — runner exits within timeout, not via SIGTERM", (t) => {
+  // Closes the round-5 review's "no dependency-down / negative path"
+  // finding: the existing hard-fail tests cover the structured-error
+  // contract for parseable-but-corrupt inputs (unparseable brief,
+  // missing manifest, missing current_state). They do NOT cover a
+  // hostile filesystem state where manifest.json is unreadable as a
+  // file at all. Without this regression, a hang in manifest-read
+  // would surface only as the 120s timeout SIGTERM — masking the
+  // real failure mode.
+  //
+  // Portable hostile shape: replace manifest.json with a DIRECTORY of
+  // the same name. readFileSync on a directory throws EISDIR on every
+  // POSIX system (including the runner's Node child); chmod-based
+  // tests would flake in CI containers.
+
+  // Arrange: fresh run, then replace the manifest file with a
+  // directory of the same name.
+  const { runId, manifestPath } = makeFreshRunForContinueTest(
+    t,
+    "3333333333333333333333333333333333333333",
+    "4444444444444444444444444444444444444444",
+  );
+  rmSync(manifestPath, { force: true });
+  mkdirSync(manifestPath, { recursive: true });
+
+  // Act + Assert: --continue must produce a structured error within
+  // CONTINUE_TEST_TIMEOUT_MS (no SIGTERM masking). assertContinueHardFails
+  // already enforces parseable JSON on stdout — under SIGTERM stdout
+  // would be empty/truncated and parseStdoutOrFail would assert.fail
+  // with the diagnostic, so this test inherits the timeout-masking
+  // negative assertion automatically.
+  //
+  // We don't pin the exact error message wording (the runner's
+  // EISDIR / ENOTFILE / "is a directory" surfaces vary by Node
+  // version); we only require: non-zero exit, JSON-parseable
+  // stdout, and SOME message that mentions the run-id or the
+  // manifest path so the operator can diagnose.
+  assertContinueHardFails(runId, [], {
+    messageRegex: /(manifest|directory|EISDIR|ENOTFILE|run-id)/i,
+    extraAssertions: (payload) => {
+      assert.ok(typeof payload.message === "string" && payload.message.length > 0,
+        "fail() payload must carry a non-empty message",
+      );
     },
   });
 });

--- a/tests/integration/end-to-end-runner.test.js
+++ b/tests/integration/end-to-end-runner.test.js
@@ -1470,87 +1470,85 @@ test("--continue --outputs-file <path>: explicit-path branch hard-fails when man
   });
 });
 
-test("--continue: manifest path is a directory (not a file) — runner exits within timeout, not via SIGTERM", (t) => {
-  // Closes the round-5 review's "no dependency-down / negative path"
-  // finding: the existing hard-fail tests cover the structured-error
-  // contract for parseable-but-corrupt inputs (unparseable brief,
-  // missing manifest, missing current_state). They do NOT cover a
-  // hostile filesystem state where manifest.json is unreadable as a
-  // file at all. Without this regression, a hang in manifest-read
-  // would surface only as the 120s timeout SIGTERM — masking the
-  // real failure mode.
-  //
-  // Portable hostile shape: replace manifest.json with a DIRECTORY of
-  // the same name. readFileSync on a directory throws EISDIR on every
-  // POSIX system (including the runner's Node child); chmod-based
-  // tests would flake in CI containers.
+// Table-driven regression for the EISDIR-as-directory hostile
+// filesystem shape. Closes the round-5 review's "no dependency-down /
+// negative path" finding: the existing hard-fail tests cover
+// parseable-but-corrupt inputs (unparseable brief, missing manifest,
+// missing current_state). They do NOT cover a hostile filesystem state
+// where manifest.json is unreadable as a file at all. Without this
+// regression, a hang in manifest-read would surface only as the 120s
+// timeout SIGTERM — masking the real failure mode.
+//
+// Portable hostile shape: replace manifest.json with a DIRECTORY of
+// the same name. readFileSync on a directory throws EISDIR on every
+// POSIX system (including the runner's Node child); chmod-based
+// tests would flake in CI containers.
+//
+// Both --continue branches (implicit-default outputs-file derivation
+// AND explicit --outputs-file <path>) route through the same
+// safeReadManifest() helper at scripts/run-review.mjs, so each branch
+// must surface the EISDIR shape as a structured fail() — a future
+// refactor that splits the two branches' manifest reads could
+// silently regress one of them, so we cover both.
+//
+// Branch label / SHAs / extra args are the only per-row deltas; the
+// arrange and the assertion contract are identical, so a table-driven
+// test is the natural shape (round-6 review #2 — antipattern-copy-paste).
+// SHAs are arbitrary 40-hex placeholders that satisfy
+// makeFreshRunForContinueTest's validator; they're decorrelated per
+// branch so concurrent test runs of the two rows write to distinct
+// run-dirs (sentinel uniqueness is also guaranteed by
+// freshNonexistentRunId, but using distinct SHAs keeps run-dir paths
+// human-readable in failure traces).
+const EISDIR_BRANCH_CASES = [
+  {
+    label: "implicit",
+    extraContinueArgs: [],
+    baseSha: "3333333333333333333333333333333333333333",
+    headSha: "4444444444444444444444444444444444444444",
+  },
+  {
+    label: "explicit-outputs-file",
+    extraContinueArgs: ["--outputs-file", "/nonexistent/x.json"],
+    baseSha: "7777777777777777777777777777777777777777",
+    headSha: "8888888888888888888888888888888888888888",
+  },
+];
 
-  // Arrange: fresh run, then replace the manifest file with a
-  // directory of the same name.
-  const { runId, manifestPath } = makeFreshRunForContinueTest(
-    t,
-    "3333333333333333333333333333333333333333",
-    "4444444444444444444444444444444444444444",
-  );
-  rmSync(manifestPath, { force: true });
-  mkdirSync(manifestPath, { recursive: true });
+for (const { label, extraContinueArgs, baseSha, headSha } of EISDIR_BRANCH_CASES) {
+  test(
+    `--continue (${label} branch): manifest path is a directory — runner exits within timeout, not via SIGTERM`,
+    (t) => {
+      // Arrange: fresh run, then replace the manifest file with a
+      // directory of the same name.
+      const { runId, manifestPath } = makeFreshRunForContinueTest(t, baseSha, headSha);
+      rmSync(manifestPath, { force: true });
+      mkdirSync(manifestPath, { recursive: true });
 
-  // Act + Assert: --continue must produce a structured error within
-  // CONTINUE_TEST_TIMEOUT_MS (no SIGTERM masking). assertContinueHardFails
-  // already enforces parseable JSON on stdout — under SIGTERM stdout
-  // would be empty/truncated and parseStdoutOrFail would assert.fail
-  // with the diagnostic, so this test inherits the timeout-masking
-  // negative assertion automatically.
-  //
-  // We don't pin the exact error message wording (the runner's
-  // EISDIR / ENOTFILE / "is a directory" surfaces vary by Node
-  // version); we only require: non-zero exit, JSON-parseable
-  // stdout, and SOME EISDIR/manifest-shape token so the regression
-  // is genuinely scoped to "runner couldn't read manifest as a
-  // file". Excludes "run-id" — that token leaks into virtually
-  // every fail() the runner emits and would weaken the regression
-  // intent (any unrelated fail-fast path could match).
-  //
-  // The structured payload's run_id field is pinned in
-  // extraAssertions instead, locking down that the
-  // manifest-corruption fail() carries the operator-actionable
-  // run-id (matches the contract on the parallel hard-fail tests
-  // above).
-  assertContinueHardFails(runId, [], {
-    messageRegex: /(manifest|directory|EISDIR|ENOTFILE)/i,
-    extraAssertions: (payload) => {
-      assert.equal(payload.run_id, runId, "structured error must carry the run-id");
+      // Act + Assert: --continue must produce a structured error within
+      // CONTINUE_TEST_TIMEOUT_MS (no SIGTERM masking).
+      // assertContinueHardFails already enforces parseable JSON on
+      // stdout — under SIGTERM stdout would be empty/truncated and
+      // parseStdoutOrFail would assert.fail with the diagnostic, so
+      // this test inherits the timeout-masking negative assertion
+      // automatically.
+      //
+      // We don't pin exact error message wording (the runner's EISDIR
+      // / ENOTFILE / "is a directory" surfaces vary by Node version);
+      // we only require: non-zero exit, JSON-parseable stdout, and
+      // SOME EISDIR/manifest-shape token so the regression is
+      // genuinely scoped to "runner couldn't read manifest as a
+      // file". Excludes "run-id" — that token leaks into virtually
+      // every fail() the runner emits and would weaken the regression
+      // intent (any unrelated fail-fast path could match). The
+      // structured payload's run_id field is pinned in
+      // extraAssertions instead.
+      assertContinueHardFails(runId, extraContinueArgs, {
+        messageRegex: /(manifest|directory|EISDIR|ENOTFILE)/i,
+        extraAssertions: (payload) => {
+          assert.equal(payload.run_id, runId, "structured error must carry the run-id");
+        },
+      });
     },
-  });
-});
-
-test("--continue --outputs-file <path>: manifest path is a directory — explicit-path branch also hard-fails (no SIGTERM)", (t) => {
-  // Parallel regression to the implicit-branch test above: the
-  // explicit --outputs-file branch routes through the same
-  // safeReadManifest() helper at scripts/run-review.mjs, so the
-  // EISDIR-as-directory hostile shape must surface as a structured
-  // fail() through this code path too. Without this, a future
-  // refactor that splits the two branches' manifest reads could
-  // silently regress one of them and the test suite would only
-  // catch it via the implicit branch.
-
-  // Arrange: fresh run, then replace the manifest file with a
-  // directory of the same name.
-  const { runId, manifestPath } = makeFreshRunForContinueTest(
-    t,
-    "7777777777777777777777777777777777777777",
-    "8888888888888888888888888888888888888888",
   );
-  rmSync(manifestPath, { force: true });
-  mkdirSync(manifestPath, { recursive: true });
-
-  // Act + Assert: --continue --outputs-file <path> must produce a
-  // structured EISDIR/manifest-shape error, not a SIGTERM. Same
-  // contract as the implicit-branch test.
-  assertContinueHardFails(runId, ["--outputs-file", "/nonexistent/x.json"], {
-    messageRegex: /(manifest|directory|EISDIR|ENOTFILE)/i,
-    extraAssertions: (payload) => {
-      assert.equal(payload.run_id, runId, "structured error must carry the run-id");
-    },
-  });
-});
+}

--- a/tests/unit/dispatch-prompt-staging.test.js
+++ b/tests/unit/dispatch-prompt-staging.test.js
@@ -541,21 +541,25 @@ test("writeSpecialistPromptsToDisk: single-shard output keeps the canonical non-
   }
 });
 
-test("FORBIDDEN_PATHS_NOTICE_FULL and FORBIDDEN_PATHS_NOTICE_SHIM share load-bearing tokens (no silent drift)", () => {
+// Load-bearing tokens both FORBIDDEN PATHS notice variants must
+// preserve. A divergent edit (e.g. updating the full rationale to
+// allow a new scratch dir but forgetting the shim) would silently
+// weaken the contract for the audience that reads the stale copy.
+// Defined at module scope so both invariants below test against the
+// same shared definition.
+const FORBIDDEN_PATHS_LOAD_BEARING_TOKENS = [
+  "NEVER write to /tmp",
+  // Both forms must name the canonical write target as the output path.
+  "ONLY allowed write target is the output path",
+];
+
+test("FORBIDDEN_PATHS_NOTICE_FULL and FORBIDDEN_PATHS_NOTICE_SHIM both carry the load-bearing tokens (no silent drift)", () => {
   // The two constants serve different audiences (full rationale for
   // the dispatch prompt, compact pointer for the ~200-token shim) but
-  // must agree on the load-bearing rule clauses. A divergent edit
-  // (e.g. someone updates the full rationale to allow a new scratch
-  // dir but forgets the shim) would silently weaken the contract for
-  // dispatched specialist Agents — the shim is what they read inline.
-  // This test guards against drift on the rule wording without
-  // demanding mechanical derivation of one form from the other.
-  const loadBearingTokens = [
-    "NEVER write to /tmp",
-    // Both forms must name the canonical write target as the output path.
-    "ONLY allowed write target is the output path",
-  ];
-  for (const token of loadBearingTokens) {
+  // must agree on the load-bearing rule clauses. This test guards
+  // against drift on the rule wording without demanding mechanical
+  // derivation of one form from the other.
+  for (const token of FORBIDDEN_PATHS_LOAD_BEARING_TOKENS) {
     assert.ok(
       FORBIDDEN_PATHS_NOTICE_FULL.includes(token),
       `FORBIDDEN_PATHS_NOTICE_FULL is missing load-bearing token: "${token}"`,
@@ -565,8 +569,12 @@ test("FORBIDDEN_PATHS_NOTICE_FULL and FORBIDDEN_PATHS_NOTICE_SHIM share load-bea
       `FORBIDDEN_PATHS_NOTICE_SHIM is missing load-bearing token: "${token}"`,
     );
   }
-  // The shim must be SHORTER than the full notice (it lives inside a
-  // documented ~200-token bound). If the shim grows past the full
+});
+
+test("FORBIDDEN_PATHS_NOTICE_SHIM is shorter than FORBIDDEN_PATHS_NOTICE_FULL (audience-inversion guard)", () => {
+  // The shim lives inside a documented ~200-token bound and is what
+  // the dispatched specialist Agent reads inline before opening the
+  // staged dispatch prompt. If the shim ever grows past the full
   // form, somebody has the audiences inverted.
   assert.ok(
     FORBIDDEN_PATHS_NOTICE_SHIM.length < FORBIDDEN_PATHS_NOTICE_FULL.length,


### PR DESCRIPTION
## Summary

The round-5 review of PR #97 verdicted GO with 19 minor findings (0 important). All 19 fixed; nothing deferred. Plus a bonus robustness fix for a real bug surfaced by one of the new regression tests.

### Fixes

- **API docs (#2):** JSDoc on `FORBIDDEN_PATHS_NOTICE_FULL` / `FORBIDDEN_PATHS_NOTICE_SHIM` naming audience + load-bearing-token contract.
- **CHANGELOG (#3):** Created `CHANGELOG.md` with an Unreleased section; older versions point at git tags / release commits (the project's existing pattern).
- **Trim compensatory comment (#4):** Long block comment on the FULL constant collapsed; kept regression history + test reference, dropped what `git grep` recovers.
- **Dead `randomBytes` import (#5/7/8/9/11):** Removed.
- **Immutability nits (#6/10/17):** `let payload` → `const` via `parseStdoutOrFail()` helper; `setManifestCurrentState` uses spread; new `stripManifestCurrentState()` uses rest-destructuring instead of `delete`.
- **Test reliability (#12):** `freshNonexistentRunId()` suffix now combines `process.pid & 0xFFFF` (4 hex) + per-call counter `& 0xFFF` (3 hex) — process-unique AND call-unique within process.
- **No conditional-branch assertions (#13):** `assertContinueHardFails` calls `parseStdoutOrFail` which uses `assert.fail` on bad stdout; the negative assertions now run on a guaranteed-bound `const`.
- **New adverse-env regression (#15):** "manifest path is a directory (not a file)" test — portable, exercises a hostile filesystem state.
- **Test hygiene (#14/18/19):** Doc comment for `extraContinueArgs` shape; test name trimmed; load-bearing-tokens test split into two single-invariant tests sharing a module-scope `FORBIDDEN_PATHS_LOAD_BEARING_TOKENS` array.

### Bonus: real readManifest EISDIR robustness fix

The new manifest-as-directory regression test surfaced a pre-existing bug: `readManifest` threw EISDIR uncaught from `--continue main()`, surfacing as `unhandled error: <stack>` — the exact stack-leak channel the runner's other corruption paths take pains to avoid. Wrapped both `--continue` `readManifest` call sites in a `safeReadManifest()` helper that catches I/O exceptions and routes them through `fail()` with a structured error naming the run-id and the underlying exception message.

### Findings explicitly not actioned

#1 ("no action needed today") and #16 ("no action required for this PR") — both flagged by the reviewer as future-vigilance only.

## Test plan

- [x] `npm test` — 301 pass (was 299, +2: split FORBIDDEN_PATHS test + manifest-as-directory regression)
- [x] `npm run lint` — 0 errors
- [x] `npm run validate:fsm` — 0 errors / 15 states
- [x] New: manifest-as-directory regression hard-fails within timeout, no SIGTERM masking
- [x] New: split load-bearing-tokens test asserts one invariant per case
- [x] All previous round-1..round-5 regressions still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)