### PR TITLE
docs(skill): require user consent before any package-missing install

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -26,7 +26,7 @@ Before any review work, follow
 ensure `ctxr-fsm` is installed, the project is initialised, the MCP
 server is registered with this client, and the supervisor is running.
 The bootstrap is idempotent and intended to be fast on the warm path
-(measured 1.5-1.8s on cycle 1) when everything is up.
+(around 1.5-1.8s once the supervisor and MCP server are already up).
 
 **If the package is missing, ASK the user before running the install
 command.** Print the proposed command in chat verbatim (the exact

--- a/SKILL.md
+++ b/SKILL.md
@@ -25,7 +25,16 @@ Before any review work, follow
 [`@.ctxr-fsm/memory/bootstrap.md`](.ctxr-fsm/memory/bootstrap.md) to
 ensure `ctxr-fsm` is installed, the project is initialised, the MCP
 server is registered with this client, and the supervisor is running.
-The bootstrap is idempotent and fast (<500ms) when everything is up.
+The bootstrap is idempotent and intended to be fast on the warm path
+(measured 1.5-1.8s on cycle 1) when everything is up.
+
+**If the package is missing, ASK the user before running the install
+command.** Print the proposed command in chat verbatim (the exact
+`uv add 'ctxr-fsm[all]'` / `pipx install 'ctxr-fsm[all]'` row from the
+bootstrap table) and require explicit go-ahead before proceeding. Do
+not auto-install. Do not chain multiple install attempts. This is the
+package-missing branch of Principle 1 (requirement pre-check, ask to
+satisfy) applied to skill startup.
 
 Then register this skill's spec + inline handlers once per project:
 


### PR DESCRIPTION
## Summary

Two surgical SKILL.md updates the cross-client bootstrap verification surfaced:

- **Consent gate on the package-missing path.** Skill explicitly asks the user before running ANY install command, prints the proposed command verbatim, and requires explicit go-ahead before proceeding. No auto-install, no chained attempts.
- **Drop unsupported \`<500ms\` warm-path claim.** Replaced with the measured 1.5-1.8s figure from cycle 1.

Dead-link audit confirmed in passing: both \`@.ctxr-fsm/memory/<file>\` imports resolve once W23-SSOT staging lands the canonical docs in the consumer project; sibling repo links (code-reviewer.md, release-readiness.md, report-format.md, reviewers.wiki/, CHANGELOG.md) all exist.

## Test plan
- [x] SKILL.md renders cleanly with the new consent paragraph
- [x] Both \`@.ctxr-fsm/memory/<file>\` references match the canonical post-W23-SSOT location
- [x] All sibling repo references (\`code-reviewer.md\`, \`release-readiness.md\`, \`report-format.md\`, \`reviewers.wiki/\`, \`CHANGELOG.md\`) exist in the working tree