### PR TITLE
refactor(skill): extract sharding.py helper

### DIFF
--- a/ctxr_skill_code_review/handlers.py
+++ b/ctxr_skill_code_review/handlers.py
@@ -37,6 +37,8 @@ from typing import Any
 import frontmatter
 from ctxr.fsm.core import InlineContext, InlineHandler
 
+from .sharding import shard_segments
+
 # ---------------------------------------------------------------------------
 # Shared constants — kept module-local; promoted to spec.StrEnums where they
 # represent closed vocabularies that flow across handler boundaries.
@@ -1133,8 +1135,16 @@ def _legacy_run_id_for(run_uuid_str: str) -> str:
     return f"{_utc_now_iso()}-{digest[:7]}"
 
 
-def _run_dir_path(run_id: str, storage_root: Path) -> Path:
-    """Deterministic shard tree: <storage>/<yyyy>/<mm>/<dd>/<ab>/<rest>/."""
+def _run_dir_path(run_id: str, storage_root: Path, *, shard_key: str | None = None) -> Path:
+    """Deterministic shard tree: ``<storage>/<yyyy>/<mm>/<dd>/<ab>/<rest5>/``.
+
+    The date prefix is parsed from ``run_id`` (the v2.5.1-shaped
+    ``YYYYMMDD-HHMMSS-<7hex>``). The shard segments come from
+    :func:`sharding.shard_segments` over ``shard_key`` (typically the
+    FSM run uuid string). When ``shard_key`` is omitted we fall back to
+    the 7-hex suffix of ``run_id`` so existing v2.5.1 ids that didn't
+    carry a separate uuid still produce a byte-identical path.
+    """
     match = re.fullmatch(r"(\d{4})(\d{2})(\d{2})-\d{6}-([0-9a-f]{7})", run_id)
     if not match:
         raise ValueError(
@@ -1142,7 +1152,11 @@ def _run_dir_path(run_id: str, storage_root: Path) -> Path:
             "(expected YYYYMMDD-HHMMSS-<7 hex>)"
         )
     yyyy, mm, dd, hash7 = match.groups()
-    return storage_root / yyyy / mm / dd / hash7[:2] / hash7[2:]
+    if shard_key is not None:
+        first, rest = shard_segments(shard_key, (2, 5))
+    else:
+        first, rest = hash7[:2], hash7[2:]
+    return storage_root / yyyy / mm / dd / first / rest
 
 
 def _atomic_write_text(path: Path, contents: str) -> None:
@@ -1655,7 +1669,7 @@ def write_run_artefacts(
     project_root = _coerce_absolute_project_root(args_bag.get("project_root"), skill_root)
     storage_root = _resolve_storage_root(project_root)
     legacy_run_id = _legacy_run_id_for(run_uuid_str)
-    run_dir = _run_dir_path(legacy_run_id, storage_root)
+    run_dir = _run_dir_path(legacy_run_id, storage_root, shard_key=run_uuid_str)
 
     report_payload = build_report_payload(legacy_run_id, env)
     _atomic_write_text(run_dir / "report.json", render_report_json(report_payload))

--- a/ctxr_skill_code_review/sharding.py
+++ b/ctxr_skill_code_review/sharding.py
@@ -1,0 +1,75 @@
+"""Deterministic content-addressed sharding for on-disk artefacts.
+
+The skill writes many small files (run reports, manifests, cached
+worker outputs) under ``<storage>/...`` trees. A single flat directory
+collapses under filesystem listing pressure once the count crosses the
+low thousands; a too-deep tree wastes inodes and makes ``ls`` painful.
+
+The middle ground is a two-level shard derived from a stable sha256
+prefix of a deterministic key (run uuid, worker key, leaf id):
+
+* ``levels=(2, 5)`` — the default. First 2 hex chars index 256 buckets,
+  next 5 hex chars give each bucket up to ~1M unique leaves before any
+  bucket fills meaningfully. Good for run-scoped artefacts where the
+  total population grows over time but per-bucket fan-out stays small.
+* ``levels=(2, 2, 3)`` — three-level variant for very long-lived
+  corpora (e.g. memory documents) where the total population is
+  expected to reach millions and the second hop helps keep ``ls`` snappy.
+* ``levels=(3, 4)`` — single-bucket-fatter variant for small, dense
+  caches where 256 first-level dirs would be sparse.
+
+The helpers are pure functions: no filesystem I/O, no time, no random.
+Callers compose them with their own date/scope prefixes (see
+``handlers._run_dir_path`` for the canonical example).
+"""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from pathlib import Path
+
+# sha256 produces a 64-char hex digest. Any (levels) tuple whose sum exceeds
+# that is a programming error and we surface it eagerly rather than silently
+# truncating.
+_HEX_DIGEST_LEN = 64
+
+
+def shard_segments(key: str, levels: tuple[int, ...] = (2, 5)) -> tuple[str, ...]:
+    """Split ``sha256(key).hexdigest()`` into segments of the given lengths.
+
+    >>> shard_segments("hello")  # doctest: +ELLIPSIS
+    ('2c', 'f24db')
+
+    The default ``(2, 5)`` matches the on-disk shard tree the skill has
+    used since v2.5.1. Pass a different tuple to opt into a deeper or
+    shallower fan-out (see module docstring).
+    """
+    if sum(levels) > _HEX_DIGEST_LEN:
+        raise ValueError(
+            f"shard_segments: sum(levels)={sum(levels)} exceeds sha256 hex "
+            f"digest length ({_HEX_DIGEST_LEN}); pick smaller segments"
+        )
+    digest = sha256(key.encode("utf-8")).hexdigest()
+    segments: list[str] = []
+    cursor = 0
+    for length in levels:
+        segments.append(digest[cursor : cursor + length])
+        cursor += length
+    return tuple(segments)
+
+
+def shard_path(
+    root: Path,
+    key: str,
+    leaf_name: str,
+    *,
+    levels: tuple[int, ...] = (2, 5),
+) -> Path:
+    """Compose ``root / <shard segments> / leaf_name``.
+
+    ``leaf_name`` is the final FILENAME (e.g. ``"manifest.json"``), not
+    a directory. Callers create the parent with ``path.parent.mkdir`` —
+    this helper performs no I/O.
+    """
+    segments = shard_segments(key, levels)
+    return root.joinpath(*segments, leaf_name)

--- a/tests/test_handlers/test_write_run_directory.py
+++ b/tests/test_handlers/test_write_run_directory.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 import uuid
+from hashlib import sha256
 from pathlib import Path
 
 import pytest
 
 from ctxr_skill_code_review.handlers import (
     _legacy_run_id_for,
+    _run_dir_path,
     build_report_payload,
     handle_write_run_directory,
     render_report_json,
@@ -66,6 +68,24 @@ def test_legacy_run_id_is_deterministic() -> None:
     # The 7-hex suffix is deterministic; the date prefix is wall-clock so
     # only the suffix can be asserted across calls.
     assert a[-7:] == b[-7:]
+
+
+def test_run_dir_path_byte_identical_after_sharding_extract() -> None:
+    """The shard tree must stay byte-for-byte identical after the
+    sharding-helper extraction. Fixture run uuid + fixture legacy run id
+    let us assert the exact path string the v2.5.1 layout produced.
+    """
+    run_uuid_str = "0190ffff-1234-7abc-89de-fedcba987654"
+    legacy_run_id = "20240101-120000-" + sha256(run_uuid_str.encode("utf-8")).hexdigest()[:7]
+    storage_root = Path("/fake/storage")
+    out = _run_dir_path(legacy_run_id, storage_root, shard_key=run_uuid_str)
+    digest = sha256(run_uuid_str.encode("utf-8")).hexdigest()
+    expected = storage_root / "2024" / "01" / "01" / digest[:2] / digest[2:7]
+    assert out == expected
+    # Back-compat: without shard_key the function falls back to the
+    # 7-hex suffix in legacy_run_id (same path for the v2.5.1 input
+    # shape).
+    assert _run_dir_path(legacy_run_id, storage_root) == expected
 
 
 def test_invalid_verdict_raises() -> None:

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,0 +1,99 @@
+"""Tests for ``ctxr_skill_code_review.sharding``.
+
+Covers determinism, segment-length contracts, the upper-bound guard
+(sum(levels) > 64), the leaf-name semantics of ``shard_path``, and a
+collision spot-check against the live ``reviewers.wiki/`` leaf corpus
+(so we know the (2, 5) default genuinely spreads our real leaf set
+across many first-level buckets).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+from ctxr_skill_code_review.sharding import shard_path, shard_segments
+
+
+def test_shard_segments_deterministic() -> None:
+    """Same key, same call → same segments. Pure function."""
+    a = shard_segments("any-key-will-do")
+    b = shard_segments("any-key-will-do")
+    assert a == b
+
+
+def test_shard_segments_default_levels() -> None:
+    """Default returns two segments of length 2 and 5."""
+    out = shard_segments("hello")
+    assert len(out) == 2
+    assert len(out[0]) == 2
+    assert len(out[1]) == 5
+    # Sanity-check the actual hex against a hand-computed digest so a
+    # future refactor that swaps the hash function can't drift silently.
+    expected = sha256(b"hello").hexdigest()
+    assert out == (expected[:2], expected[2:7])
+
+
+def test_shard_segments_custom_levels() -> None:
+    """A (3, 4, 5) tuple splits into three segments at the correct offsets."""
+    out = shard_segments("hello", (3, 4, 5))
+    digest = sha256(b"hello").hexdigest()
+    assert out == (digest[:3], digest[3:7], digest[7:12])
+    assert [len(s) for s in out] == [3, 4, 5]
+
+
+def test_shard_segments_invalid_levels() -> None:
+    """sum(levels) > 64 is a programming error and raises eagerly."""
+    with pytest.raises(ValueError, match="exceeds sha256"):
+        shard_segments("x", (32, 33))
+
+
+def test_shard_path_combines() -> None:
+    """``shard_path`` appends the leaf NAME (a file) to the segment dirs."""
+    digest = sha256(b"k").hexdigest()
+    p = shard_path(Path("/r"), "k", "name.json")
+    assert p == Path("/r") / digest[:2] / digest[2:7] / "name.json"
+    # The final component is a file name, not a directory marker.
+    assert p.name == "name.json"
+
+
+def test_shard_path_respects_custom_levels() -> None:
+    """``levels`` is a keyword-only override; the helper honours it."""
+    digest = sha256(b"k").hexdigest()
+    p = shard_path(Path("/r"), "k", "leaf.bin", levels=(3, 4))
+    assert p == Path("/r") / digest[:3] / digest[3:7] / "leaf.bin"
+
+
+def test_no_collisions_in_wiki_corpus() -> None:
+    """Spread test: every leaf id under reviewers.wiki/ hashes to a unique
+    (2, 5) shard tuple, and no first-level bucket holds more than a small
+    handful (smoke-test that 256 buckets aren't pathologically uneven for
+    our real corpus).
+    """
+    wiki_root = Path(__file__).resolve().parent.parent / "reviewers.wiki"
+    if not wiki_root.is_dir():
+        pytest.skip(f"reviewers.wiki/ not present at {wiki_root}")
+    leaf_ids = [
+        child.name
+        for child in sorted(wiki_root.iterdir())
+        if child.is_dir() and (child / "index.md").is_file()
+    ]
+    assert leaf_ids, "expected at least one leaf reviewer under reviewers.wiki/"
+    shards = [shard_segments(leaf_id) for leaf_id in leaf_ids]
+    # Every leaf maps to a unique shard tuple (no two leaves share both
+    # segments — collision would mean two leaves write to the same dir).
+    assert len(set(shards)) == len(shards)
+    # No first-level bucket should be wildly fuller than the rest; with
+    # 256 buckets and ~100 leaves we expect at most ~4 per bucket in the
+    # average tail. Use 6 as a loose ceiling — a regression that drove
+    # everything into one bucket would trip it.
+    first_level_counts = Counter(s[0] for s in shards)
+    worst_bucket = max(first_level_counts.values())
+    assert worst_bucket <= 6, (
+        f"first-level bucket fan-out is unexpectedly uneven: "
+        f"worst bucket holds {worst_bucket} leaves "
+        f"(top 5: {first_level_counts.most_common(5)})"
+    )


### PR DESCRIPTION
PR 1/5 of skill-code-review predictability + chunking cascade. Pure code-move; zero behaviour change. Per plan in /Users/developer/.claude/plans/how-it-fits-toasty-gray.md.

Adds `ctxr_skill_code_review/sharding.py` with two pure helpers:

- `shard_segments(key, levels=(2, 5))` — sha256(key) split into segments of the requested lengths; eager guard when `sum(levels) > 64`.
- `shard_path(root, key, leaf_name, *, levels=(2, 5))` — composes `root / <segments> / leaf_name`, where `leaf_name` is a FILE (no I/O).

Routes `handlers._run_dir_path` through `shard_segments`:

- New optional `shard_key` kwarg lets the caller pass the FSM run uuid string explicitly; without it the function falls back to the 7-hex suffix of `legacy_run_id` so existing v2.5.1-shaped inputs produce a byte-identical path.
- `build_and_write_run_directory` passes `shard_key=run_uuid_str`, which is byte-identical to the prior `hash7[:2] + hash7[2:]` since `hash7 == sha256(run_uuid_str).hexdigest()[:7]`.

Tests:

- `tests/test_sharding.py` — determinism, default + custom levels, sum-over-64 guard, `shard_path` leaf-name semantics, no-collision spread check across the live `reviewers.wiki/` leaf corpus.
- `tests/test_handlers/test_write_run_directory.py` — new `test_run_dir_path_byte_identical_after_sharding_extract` pins the exact path string for a fixture run uuid before and after the extraction.