### PR TITLE
feat(skill): pin allowed_tools per worker state + tool-surface table

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -118,6 +118,37 @@ The cap on parallel specialists is the `cap` field from
 `risk_tier_triage`: `trivial=3`, `lite=8`, `full=20`, `sensitive=30`,
 overridable by `args["max-reviewers"]` (clamped to `[3, 50]`).
 
+## Tool surface per state
+
+Each worker state pins an `allowed_tools` allowlist in the FSM spec.
+The list is the exact set of harness tools a sub-agent dispatched for
+that state may call. Tool ids use the Claude Code permission shape
+(`Bash(<prefix>:*)` for scoped shell commands, bare tool names for
+everything else); other harnesses translate at dispatch time.
+
+| State                  | `allowed_tools`                                                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scan_project`         | `Bash(git diff:*)`, `Bash(git log:*)`, `Bash(git status:*)`, `Bash(git ls-files:*)`, `Bash(cat:*)`, `Read`, `Glob`                                 |
+| `tree_descend`         | `Read`                                                                                                                                             |
+| `llm_trim`             | _(none — pure reasoning over the brief)_                                                                                                           |
+| `tool_discovery`       | `Bash(eslint:*)`, `Bash(ruff:*)`, `Bash(mypy:*)`, `Bash(npm test:*)`, `Bash(pytest:*)`, `Bash(cargo:*)`, `Bash(go test:*)`, `Bash(which:*)`, `Read` |
+| `dispatch_specialists` | `Read`, `Grep`, `Glob`, `WebFetch`, `Bash(git diff:*)`, `Bash(git log:*)`                                                                          |
+
+Inline states (`risk_tier_triage`, `activate_leaves`,
+`collect_findings`, `verify_coverage`, `synthesize_release_readiness`,
+`write_run_directory`, `emit_stdout`, `short_circuit_exit`,
+`stage_a_empty`) and the `terminal` state have an empty allowlist —
+they run server-side inside ctxr-fsm and are never dispatched to a
+sub-agent.
+
+When dispatching a sub-agent for a worker state, FORWARD this state's
+`allowed_tools` verbatim into the sub-agent's tool permission shape
+(Claude Code: `--allowedTools=<list>`; Codex equivalent: `--tools`;
+Cursor: equivalent). Then on every non-`fsm.*` tool call your
+sub-agent makes, call `fsm.observe_tool_call` so the drift detector
+can audit. Violations raise `off_allowlist_tool_call` (weight 5.0);
+cumulative > 10 auto-pauses the run.
+
 ## What the skill produces
 
 A `report.md` (markdown) plus `report.json` (machine-readable) plus

--- a/ctxr_skill_code_review/spec.py
+++ b/ctxr_skill_code_review/spec.py
@@ -640,6 +640,15 @@ def _scan_project() -> State:
             # "diff_stats.lines_changed is a non-negative integer"
             Predicate("diff_stats.lines_changed >= 0"),
         ],
+        allowed_tools=[
+            "Bash(git diff:*)",
+            "Bash(git log:*)",
+            "Bash(git status:*)",
+            "Bash(git ls-files:*)",
+            "Bash(cat:*)",
+            "Read",
+            "Glob",
+        ],
         transitions=[Transition(to="risk_tier_triage", when=TransitionKind.always)],
     )
 
@@ -737,6 +746,7 @@ def _tree_descend() -> State:
         ),
         outputs=["stage_a_candidates", "descent_path"],
         post_validations=[Predicate("len(stage_a_candidates) >= 0")],
+        allowed_tools=["Read"],
         transitions=[
             Transition(
                 to="stage_a_empty",
@@ -770,6 +780,7 @@ def _llm_trim() -> State:
         ),
         outputs=["picked_leaves", "rejected_leaves", "coverage_rescues"],
         post_validations=[Predicate("len(picked_leaves) >= 0")],
+        allowed_tools=[],
         transitions=[Transition(to="tool_discovery", when=TransitionKind.always)],
     )
 
@@ -787,6 +798,17 @@ def _tool_discovery() -> State:
             response_schema=_tool_runner_schema(),
         ),
         outputs=["tool_results"],
+        allowed_tools=[
+            "Bash(eslint:*)",
+            "Bash(ruff:*)",
+            "Bash(mypy:*)",
+            "Bash(npm test:*)",
+            "Bash(pytest:*)",
+            "Bash(cargo:*)",
+            "Bash(go test:*)",
+            "Bash(which:*)",
+            "Read",
+        ],
         transitions=[Transition(to="dispatch_specialists", when=TransitionKind.always)],
     )
 
@@ -813,6 +835,14 @@ def _dispatch_specialists() -> State:
         ),
         outputs=["specialist_outputs"],
         post_validations=[Predicate("len(specialist_outputs) >= 0")],
+        allowed_tools=[
+            "Read",
+            "Grep",
+            "Glob",
+            "WebFetch",
+            "Bash(git diff:*)",
+            "Bash(git log:*)",
+        ],
         transitions=[Transition(to="collect_findings", when=TransitionKind.always)],
     )
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -126,3 +126,63 @@ def test_stage_a_empty_transition_when_no_activated_leaves() -> None:
     stage_a = state.transitions[0]
     assert stage_a.to == "stage_a_empty"
     assert "len(activated_leaves) == 0" in stage_a.when.expression  # type: ignore[union-attr]
+
+
+def test_worker_states_have_allowed_tools_pinned() -> None:
+    """Each worker state pins an `allowed_tools` allowlist per the spec.
+
+    The allowlist is the tool surface forwarded to the dispatched
+    sub-agent. Four of the five worker states expose a non-empty list;
+    ``llm_trim`` is intentionally empty because it is pure reasoning
+    over the brief. Inline / terminal states keep the default empty
+    list — they never see a sub-agent.
+    """
+    expected: dict[str, list[str]] = {
+        "scan_project": [
+            "Bash(git diff:*)",
+            "Bash(git log:*)",
+            "Bash(git status:*)",
+            "Bash(git ls-files:*)",
+            "Bash(cat:*)",
+            "Read",
+            "Glob",
+        ],
+        "tree_descend": ["Read"],
+        "llm_trim": [],
+        "tool_discovery": [
+            "Bash(eslint:*)",
+            "Bash(ruff:*)",
+            "Bash(mypy:*)",
+            "Bash(npm test:*)",
+            "Bash(pytest:*)",
+            "Bash(cargo:*)",
+            "Bash(go test:*)",
+            "Bash(which:*)",
+            "Read",
+        ],
+        "dispatch_specialists": [
+            "Read",
+            "Grep",
+            "Glob",
+            "WebFetch",
+            "Bash(git diff:*)",
+            "Bash(git log:*)",
+        ],
+    }
+    worker_state_ids = {
+        state.id for state in fsm.states if state.worker is not None
+    }
+    assert worker_state_ids == set(expected.keys()), (
+        f"worker-state set drifted: got {sorted(worker_state_ids)}"
+    )
+    for state_id, want in expected.items():
+        got = fsm.get_state(state_id).allowed_tools
+        assert got == want, (
+            f"{state_id}: allowed_tools drift — got {got}, want {want}"
+        )
+    # Worker states other than `llm_trim` must carry a non-empty allowlist.
+    for state_id, want in expected.items():
+        if state_id == "llm_trim":
+            assert want == [], "llm_trim allowlist must stay empty"
+        else:
+            assert len(want) > 0, f"{state_id} allowlist unexpectedly empty"


### PR DESCRIPTION
## Summary

- Each of the 5 worker states (`scan_project`, `tree_descend`, `llm_trim`, `tool_discovery`, `dispatch_specialists`) now pins an explicit `allowed_tools` allowlist in the FSM spec
- `SKILL.md` adds a **Tool surface per state** section with the full table and an instruction paragraph telling orchestrators to forward each state's allowlist verbatim into the dispatched sub-agent's tool-permission shape (Claude Code `--allowedTools`, Codex `--tools`, Cursor equivalent), and to call `fsm.observe_tool_call` on every non-`fsm.*` tool call so the drift detector can audit
- `llm_trim` keeps an empty allowlist (pure reasoning over the brief); inline/terminal states are never dispatched, so their default empty allowlist is unchanged
- New test `test_worker_states_have_allowed_tools_pinned` asserts the exact allowlist per worker state and that the worker-state set itself hasn't drifted

## Test plan

- [x] `ruff check` — clean
- [x] `mypy --strict` — clean
- [x] `pytest` — 82 passed (incl. new `test_worker_states_have_allowed_tools_pinned`)
- [x] `FsmSpec.validate()` — valid, errors=[]