### PR TITLE
feat(skill): per-state verifier panels (5 worker states) + LLM verifier_handler with structural fallback

### DIFF
--- a/ctxr_skill_code_review/install.py
+++ b/ctxr_skill_code_review/install.py
@@ -28,6 +28,7 @@ from ctxr.fsm.sqlite import Project
 
 from ctxr_skill_code_review.handlers import INLINE_HANDLERS
 from ctxr_skill_code_review.spec import SPEC_ID, fsm
+from ctxr_skill_code_review.verifier_handler import install_verifier_handler
 
 
 def _resolve_db_path(project_db: Path | str | None) -> Path:
@@ -127,6 +128,14 @@ def register(
     # the same process don't clash.
     registry = get_default_registry()
     registry.register_many(SPEC_ID, INLINE_HANDLERS)
+
+    # Adversarial verifier panels: install the LLM-driven handler when a
+    # dispatcher is configured (env var or ad-hoc wiring); otherwise the
+    # engine's built-in structural verifier stays in charge so the gate
+    # still produces a verdict. install_verifier_handler is idempotent
+    # and intentionally NOT surfaced in the envelope so the JSON shape
+    # consumed by the W14f smoke pipeline stays byte-stable.
+    install_verifier_handler()
 
     return {
         "spec_id": spec_result.spec.slug,

--- a/ctxr_skill_code_review/spec.py
+++ b/ctxr_skill_code_review/spec.py
@@ -44,6 +44,7 @@ from ctxr.fsm import (
 # InlineSpec hasn't been promoted to the ergonomic top-level facade yet;
 # import it from ctxr.fsm.core where the W14a engine extension defines it.
 from ctxr.fsm.core import InlineSpec
+from ctxr.fsm.core.models import VerifierSpec
 
 # ---------------------------------------------------------------------------
 # Enum-discipline (W14i prospective) — closed vocabularies as StrEnums
@@ -135,6 +136,54 @@ def _load_worker_prompt(name: str) -> str:
         resources.files("ctxr_skill_code_review.workers")
         .joinpath(f"{name}.md")
         .read_text(encoding="utf-8")
+    )
+
+
+def _load_verifier_prompt(name: str) -> str:
+    """Read a verifier prompt .md from the bundled :mod:`verifiers` package.
+
+    Mirror of :func:`_load_worker_prompt` for the per-state adversarial
+    verifier templates declared on each worker State's ``verifier`` field.
+    """
+    return (
+        resources.files("ctxr_skill_code_review.verifiers")
+        .joinpath(f"{name}.md")
+        .read_text(encoding="utf-8")
+    )
+
+
+# Shared response schema for every verifier panel vote — the panel's
+# output is the {verdict, reason} envelope, NOT the worker's output
+# shape. The structural verifier (in :mod:`ctxr.fsm.core.verifier`)
+# already re-checks the worker's response schema against the committed
+# outputs; the LLM panel layers a semantic check on top.
+_VERIFIER_VOTE_SCHEMA: ResponseSchema = ResponseSchema.model_validate({
+    "schema": {
+        "type": "object",
+        "required": ["verdict", "reason"],
+        "properties": {
+            "verdict": {
+                "type": "string",
+                "enum": ["passed", "rejected"],
+            },
+            "reason": {
+                "type": "string",
+                "maxLength": 280,
+            },
+        },
+    }
+})
+
+
+def _verifier_for(state_id: str) -> VerifierSpec:
+    """Build the canonical 3-voter / 2-majority verifier for a worker state."""
+    return VerifierSpec(
+        role=f"verify-{state_id}",
+        prompt_template=_load_verifier_prompt(state_id),
+        prompt_template_language="markdown",
+        response_schema=_VERIFIER_VOTE_SCHEMA,
+        majority_threshold=2,
+        parallel_count=3,
     )
 
 
@@ -649,6 +698,7 @@ def _scan_project() -> State:
             "Read",
             "Glob",
         ],
+        verifier=_verifier_for("scan_project"),
         transitions=[Transition(to="risk_tier_triage", when=TransitionKind.always)],
     )
 
@@ -747,6 +797,7 @@ def _tree_descend() -> State:
         outputs=["stage_a_candidates", "descent_path"],
         post_validations=[Predicate("len(stage_a_candidates) >= 0")],
         allowed_tools=["Read"],
+        verifier=_verifier_for("tree_descend"),
         transitions=[
             Transition(
                 to="stage_a_empty",
@@ -781,6 +832,7 @@ def _llm_trim() -> State:
         outputs=["picked_leaves", "rejected_leaves", "coverage_rescues"],
         post_validations=[Predicate("len(picked_leaves) >= 0")],
         allowed_tools=[],
+        verifier=_verifier_for("llm_trim"),
         transitions=[Transition(to="tool_discovery", when=TransitionKind.always)],
     )
 
@@ -809,6 +861,7 @@ def _tool_discovery() -> State:
             "Bash(which:*)",
             "Read",
         ],
+        verifier=_verifier_for("tool_discovery"),
         transitions=[Transition(to="dispatch_specialists", when=TransitionKind.always)],
     )
 
@@ -843,6 +896,7 @@ def _dispatch_specialists() -> State:
             "Bash(git diff:*)",
             "Bash(git log:*)",
         ],
+        verifier=_verifier_for("dispatch_specialists"),
         transitions=[Transition(to="collect_findings", when=TransitionKind.always)],
     )
 

--- a/ctxr_skill_code_review/verifier_handler.py
+++ b/ctxr_skill_code_review/verifier_handler.py
@@ -1,0 +1,256 @@
+"""LLM-driven verifier panel handler for the skill-code-review FSM spec.
+
+The W12 verifier surface (see :mod:`ctxr.fsm.core.verifier`) ships with
+a built-in *structural* fallback that re-checks the worker's response
+schema. This module layers an adversarial *LLM panel* on top of that
+fallback for the five worker states: each state's
+:class:`~ctxr.fsm.core.models.VerifierSpec` carries a
+``prompt_template`` (rendered against the worker's brief + outputs) and
+asks the same Agent harness the workers themselves use to cast
+``parallel_count`` independent votes.
+
+Design notes
+------------
+
+* The handler signature mirrors :data:`ctxr.fsm.core.verifier.VerifierHandler`
+  exactly so :func:`set_verifier_handler` can install it as a drop-in
+  replacement for the structural fallback.
+* When the dispatch primitive is unavailable (test env without an LLM
+  bridge, CI box without API creds), :func:`install_verifier_handler`
+  skips registration so the engine continues to use the structural
+  fallback. This preserves Principle 1 (require, don't improvise) while
+  keeping the surface always-live.
+* The CALLER is responsible for wiring an LLM dispatch callable through
+  the ``CTXR_LLM_VERIFIER_DISPATCH`` plug-in (see :func:`_get_dispatcher`).
+  We do NOT import a concrete Agent SDK here — that would couple the
+  skill to a specific harness and break the cross-harness model the
+  workers themselves follow.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from importlib import import_module, resources
+from typing import Any
+
+from ctxr.fsm.core.models import Brief, VerifierSpec, VerifierVerdict
+from ctxr.fsm.core.prompts import PromptContext, PromptRenderer
+from ctxr.fsm.core.verifier import VerifierVote, set_verifier_handler
+
+__all__ = [
+    "install_verifier_handler",
+    "llm_verifier_handler",
+    "load_verifier_prompt",
+]
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher resolution
+# ---------------------------------------------------------------------------
+
+
+LlmDispatcher = Callable[[str, dict[str, Any]], str]
+"""Dispatch primitive: ``(prompt, context) -> raw_json_string``.
+
+The orchestrator (or test harness) installs an instance of this type
+either by setting the ``CTXR_LLM_VERIFIER_DISPATCH`` env var to a
+dotted ``package.module:callable`` path, or by importing
+:mod:`ctxr_skill_code_review.verifier_handler` and assigning
+:data:`_DISPATCHER` directly. The returned string MUST be parseable as
+JSON matching ``{"verdict": "passed"|"rejected", "reason": str}``.
+"""
+
+
+_DISPATCHER: LlmDispatcher | None = None
+
+
+def _resolve_dotted(path: str) -> Any:
+    module_path, _, attr = path.partition(":")
+    if not module_path or not attr:
+        raise ValueError(
+            f"CTXR_LLM_VERIFIER_DISPATCH must be 'package.module:callable', got {path!r}"
+        )
+    module = import_module(module_path)
+    return getattr(module, attr)
+
+
+def _get_dispatcher() -> LlmDispatcher | None:
+    """Return the configured LLM dispatcher, or ``None`` if unavailable.
+
+    Resolution order:
+
+    1. The module-level :data:`_DISPATCHER` set by ad-hoc test wiring.
+    2. The ``CTXR_LLM_VERIFIER_DISPATCH`` env var, resolved as a dotted
+       ``package.module:callable`` path.
+    3. ``None`` — the caller (typically :func:`install_verifier_handler`)
+       falls back to the engine's structural verifier.
+    """
+    if _DISPATCHER is not None:
+        return _DISPATCHER
+    env = os.environ.get("CTXR_LLM_VERIFIER_DISPATCH")
+    if env:
+        candidate = _resolve_dotted(env)
+        if callable(candidate):
+            return candidate  # type: ignore[no-any-return]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Prompt loader + renderer
+# ---------------------------------------------------------------------------
+
+
+_RENDERER: PromptRenderer | None = None
+
+
+def _get_renderer() -> PromptRenderer:
+    global _RENDERER
+    if _RENDERER is None:
+        _RENDERER = PromptRenderer(allow_model_import=False)
+    return _RENDERER
+
+
+def load_verifier_prompt(name: str) -> str:
+    """Read a verifier prompt ``.md`` from the bundled :mod:`verifiers` package."""
+    return (
+        resources.files("ctxr_skill_code_review.verifiers")
+        .joinpath(f"{name}.md")
+        .read_text(encoding="utf-8")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vote parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_vote(raw: str) -> VerifierVote:
+    """Parse a dispatcher response into a :class:`VerifierVote`.
+
+    Any parse failure (non-JSON, missing keys, unknown verdict) becomes
+    a *rejected* vote with the error embedded in the reason. We fail
+    closed: a malformed verifier MUST NOT silently bypass the gate.
+    """
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return VerifierVote(
+            verdict=VerifierVerdict.rejected,
+            reason=f"verifier_response_not_json: {exc}",
+        )
+    if not isinstance(payload, dict):
+        return VerifierVote(
+            verdict=VerifierVerdict.rejected,
+            reason=f"verifier_response_not_object: {type(payload).__name__}",
+        )
+    verdict_raw = payload.get("verdict")
+    reason = str(payload.get("reason", ""))[:280]
+    if verdict_raw == VerifierVerdict.passed.value:
+        return VerifierVote(verdict=VerifierVerdict.passed, reason=reason)
+    if verdict_raw == VerifierVerdict.rejected.value:
+        return VerifierVote(verdict=VerifierVerdict.rejected, reason=reason)
+    return VerifierVote(
+        verdict=VerifierVerdict.rejected,
+        reason=f"unknown_verdict: {verdict_raw!r}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+def llm_verifier_handler(
+    verifier: VerifierSpec,
+    brief: Brief,
+    outputs: dict[str, Any],
+) -> list[VerifierVote]:
+    """Dispatch ``verifier.parallel_count`` LLM votes and return them.
+
+    Each vote is an independent LLM call. The prompt is rendered with
+    the worker's :class:`Brief` and committed ``outputs`` exposed via
+    the :class:`PromptContext` ``metadata`` dict so the templates can
+    use ``{{ metadata.get("brief", {}) | json }}`` /
+    ``{{ metadata.get("outputs", {}) | json }}`` markers that survive
+    register-time smoke validation (which runs against an empty
+    ``PromptContext``).
+
+    Falls back to a single rejected vote (``no_llm_dispatcher``) if no
+    dispatcher is wired AND this handler was somehow installed anyway;
+    the well-trodden path is for :func:`install_verifier_handler` to
+    skip registration entirely so the engine's structural fallback runs.
+    """
+    dispatcher = _get_dispatcher()
+    if dispatcher is None:
+        return [
+            VerifierVote(
+                verdict=VerifierVerdict.rejected,
+                reason="no_llm_dispatcher_registered",
+            )
+            for _ in range(verifier.parallel_count)
+        ]
+
+    renderer = _get_renderer()
+    context = PromptContext(
+        state_id=brief.state,
+        state_kind="verifier",
+        metadata={
+            "brief": brief.model_dump(mode="json"),
+            "outputs": outputs,
+            "verifier_role": verifier.role,
+        },
+    )
+    rendered_prompt = renderer.render(verifier.prompt_template, context)
+
+    votes: list[VerifierVote] = []
+    for slot in range(verifier.parallel_count):
+        try:
+            raw = dispatcher(
+                rendered_prompt,
+                {
+                    "role": verifier.role,
+                    "slot": slot,
+                    "state_id": brief.state,
+                    "run_id": str(brief.run_id),
+                },
+            )
+        except Exception as exc:
+            votes.append(
+                VerifierVote(
+                    verdict=VerifierVerdict.rejected,
+                    reason=f"dispatcher_raised: {type(exc).__name__}: {exc}"[:280],
+                )
+            )
+            continue
+        votes.append(_parse_vote(raw))
+    return votes
+
+
+# ---------------------------------------------------------------------------
+# Installer
+# ---------------------------------------------------------------------------
+
+
+_INSTALLED: bool = False
+
+
+def install_verifier_handler() -> bool:
+    """Install :func:`llm_verifier_handler` as the process-wide handler.
+
+    Idempotent: subsequent calls are no-ops (the handler is already in
+    place). Returns ``True`` if a handler was installed (or was already
+    installed), ``False`` if no LLM dispatcher is configured and the
+    engine's structural fallback was left in place.
+    """
+    global _INSTALLED
+    if _INSTALLED:
+        return True
+    if _get_dispatcher() is None:
+        # No LLM bridge — leave the structural fallback in charge so
+        # the gate still produces a verdict instead of erroring out.
+        return False
+    set_verifier_handler(llm_verifier_handler)
+    _INSTALLED = True
+    return True

--- a/ctxr_skill_code_review/verifiers/__init__.py
+++ b/ctxr_skill_code_review/verifiers/__init__.py
@@ -1,0 +1,12 @@
+"""Verifier prompt templates for the skill-code-review FSM spec.
+
+Each ``.md`` file in this package is a Jinja2-rendered prompt that the
+verifier panel handler (see :mod:`ctxr_skill_code_review.verifier_handler`)
+dispatches in parallel against a worker state's committed outputs.
+
+The templates use ``{{ metadata.get("brief", {}) | json }}`` and
+``{{ metadata.get("outputs", {}) | json }}`` so register-time smoke
+validation (empty :class:`~ctxr.fsm.core.prompts.PromptContext`) succeeds
+while runtime renders fill the placeholders with the worker's brief +
+outputs payload.
+"""

--- a/ctxr_skill_code_review/verifiers/dispatch_specialists.md
+++ b/ctxr_skill_code_review/verifiers/dispatch_specialists.md
@@ -1,0 +1,43 @@
+# Verifier: dispatch_specialists
+
+You are an adversarial verifier for the `dispatch_specialists` worker
+of the `code-reviewer` FSM. Specialists produce per-leaf findings; the
+verifier ensures every finding is traceable back to a real leaf, a real
+changed file, and a known severity.
+
+## Brief
+
+```json
+{{ metadata.get("brief", {}) | json }}
+```
+
+## Outputs
+
+```json
+{{ metadata.get("outputs", {}) | json }}
+```
+
+## Reject if ANY of these hold
+
+1. Any `specialist_outputs[].id` is NOT present in this iteration's
+   `inputs.picked_leaves[].id` batch — specialists must only emit
+   under ids the dispatcher actually scheduled.
+2. Any finding's `severity` is outside the closed taxonomy
+   `{"critical", "important", "minor"}`.
+3. Any finding's `file` is NOT present in the brief's
+   `inputs.changed_paths[]` — findings against unchanged files are a
+   coverage leak.
+4. Any `specialist_outputs[]` entry has `status == "skipped"` without
+   a non-empty `skip_reason`.
+
+## Output format (STRICT JSON)
+
+```json
+{
+  "verdict": "passed",
+  "reason": "<280-char explanation>"
+}
+```
+
+`verdict` MUST be `"passed"` or `"rejected"`. `reason` MUST be at most
+280 characters. Do NOT emit any text outside the JSON object.

--- a/ctxr_skill_code_review/verifiers/llm_trim.md
+++ b/ctxr_skill_code_review/verifiers/llm_trim.md
@@ -1,0 +1,42 @@
+# Verifier: llm_trim
+
+You are an adversarial verifier for the `llm_trim` worker of the
+`code-reviewer` FSM. The trim worker picks up to `cap` leaves from
+`stage_a_candidates[]` with one-sentence justifications and emits
+coverage rescues for files no picked leaf would otherwise cover.
+
+## Brief
+
+```json
+{{ metadata.get("brief", {}) | json }}
+```
+
+## Outputs
+
+```json
+{{ metadata.get("outputs", {}) | json }}
+```
+
+## Reject if ANY of these hold
+
+1. `len(picked_leaves)` exceeds the brief's `inputs.cap` integer.
+2. Any entry in `picked_leaves[]` is missing a non-empty
+   `justification` string.
+3. The union of `picked_leaves[].id` and `rejected_leaves[].id` does
+   NOT equal the set of `inputs.stage_a_candidates[].id` (every
+   candidate must be either picked or rejected — no orphans, no
+   duplicates).
+4. Any entry in `coverage_rescues[]` has a `rescued_leaf` that is NOT
+   present in `picked_leaves[].id`.
+
+## Output format (STRICT JSON)
+
+```json
+{
+  "verdict": "passed",
+  "reason": "<280-char explanation>"
+}
+```
+
+`verdict` MUST be `"passed"` or `"rejected"`. `reason` MUST be at most
+280 characters. Do NOT emit any text outside the JSON object.

--- a/ctxr_skill_code_review/verifiers/scan_project.md
+++ b/ctxr_skill_code_review/verifiers/scan_project.md
@@ -1,0 +1,45 @@
+# Verifier: scan_project
+
+You are an adversarial verifier for the `scan_project` worker of the
+`code-reviewer` FSM. Re-check the worker's committed outputs against the
+following rejection criteria. Be skeptical: a passing verdict means the
+output is demonstrably safe to forward to the next state.
+
+## Brief (the worker was asked to produce a Project Profile)
+
+```json
+{{ metadata.get("brief", {}) | json }}
+```
+
+## Outputs (what the worker actually returned)
+
+```json
+{{ metadata.get("outputs", {}) | json }}
+```
+
+## Reject if ANY of these hold
+
+1. `project_profile.languages` is empty or missing.
+2. Any entry in `project_profile.frameworks` is NOT a name actually
+   appearing in the repo's dependencies (package.json, pyproject.toml,
+   go.mod, Cargo.toml, etc.) — i.e. the worker hallucinated a framework
+   the project does not use.
+3. `diff_stats.lines_changed` or `diff_stats.files_changed` is off by
+   more than 20% from what `git diff --stat` would report for the same
+   `base..head` range.
+4. `changed_paths` is not an array of strings, or contains absolute
+   paths (the contract is repo-relative paths only).
+
+## Output format (STRICT JSON)
+
+Return a single JSON object with exactly these two fields:
+
+```json
+{
+  "verdict": "passed",
+  "reason": "<280-char explanation>"
+}
+```
+
+`verdict` MUST be `"passed"` or `"rejected"`. `reason` MUST be at most
+280 characters. Do NOT emit any text outside the JSON object.

--- a/ctxr_skill_code_review/verifiers/tool_discovery.md
+++ b/ctxr_skill_code_review/verifiers/tool_discovery.md
@@ -1,0 +1,42 @@
+# Verifier: tool_discovery
+
+You are an adversarial verifier for the `tool_discovery` worker of the
+`code-reviewer` FSM. The tool runner only executes tools that one of
+`picked_leaves[].tools[]` actually declares, and every skipped row must
+explain WHY it was skipped.
+
+## Brief
+
+```json
+{{ metadata.get("brief", {}) | json }}
+```
+
+## Outputs
+
+```json
+{{ metadata.get("outputs", {}) | json }}
+```
+
+## Reject if ANY of these hold
+
+1. Any `tool_results[].name` is NOT declared in the brief's
+   `inputs.picked_leaves[].tools[].name` set — the runner must not
+   invent tools the trim worker did not authorise.
+2. Any `tool_results[]` entry with `status == "skipped"` is missing a
+   non-empty `reason` field.
+3. Any `tool_results[]` entry has a `status` outside
+   `{"pass", "fail", "skipped"}`.
+4. Any `tool_results[]` entry with `status` in `{"pass", "fail"}`
+   omits the `findings` integer.
+
+## Output format (STRICT JSON)
+
+```json
+{
+  "verdict": "passed",
+  "reason": "<280-char explanation>"
+}
+```
+
+`verdict` MUST be `"passed"` or `"rejected"`. `reason` MUST be at most
+280 characters. Do NOT emit any text outside the JSON object.

--- a/ctxr_skill_code_review/verifiers/tree_descend.md
+++ b/ctxr_skill_code_review/verifiers/tree_descend.md
@@ -1,0 +1,44 @@
+# Verifier: tree_descend
+
+You are an adversarial verifier for the `tree_descend` worker of the
+`code-reviewer` FSM. Cross-check the worker's `stage_a_candidates[]`
+against the brief's `activated_leaves[]`: the descender must NOT
+fabricate candidates and must NOT lose v2 frontmatter fields.
+
+## Brief
+
+```json
+{{ metadata.get("brief", {}) | json }}
+```
+
+## Outputs
+
+```json
+{{ metadata.get("outputs", {}) | json }}
+```
+
+## Reject if ANY of these hold
+
+1. Any leaf in `stage_a_candidates[]` has an empty `activation_match`
+   array (every candidate MUST have at least one activation reason
+   carried through from `activated_leaves[]`).
+2. Any leaf's `id` in `stage_a_candidates[]` is NOT present in the
+   brief's `inputs.activated_leaves[].id` set — the descender is a
+   filter, not an inventor.
+3. `descent_path` is missing or not an array of strings.
+4. Any v2 frontmatter field present on the corresponding
+   `activated_leaves[]` entry (`focus`, `dimensions`, `audit_surface`,
+   `languages`, `tools`, `tags`, `covers`, `type`, `file_globs`) is
+   dropped in the matching `stage_a_candidates[]` entry.
+
+## Output format (STRICT JSON)
+
+```json
+{
+  "verdict": "passed",
+  "reason": "<280-char explanation>"
+}
+```
+
+`verdict` MUST be `"passed"` or `"rejected"`. `reason` MUST be at most
+280 characters. Do NOT emit any text outside the JSON object.

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -186,3 +186,28 @@ def test_worker_states_have_allowed_tools_pinned() -> None:
             assert want == [], "llm_trim allowlist must stay empty"
         else:
             assert len(want) > 0, f"{state_id} allowlist unexpectedly empty"
+
+
+def test_each_worker_has_verifier() -> None:
+    """Every worker state ships a 3-voter / 2-majority verifier panel.
+
+    The verifier is the adversarial gate that re-checks the worker's
+    committed outputs before the engine transitions; the spec must
+    declare one for every worker state so the panel can never silently
+    no-op.
+    """
+    worker_states = [s for s in fsm.states if s.worker is not None]
+    assert len(worker_states) == 5, "spec must still ship 5 worker states"
+    for state in worker_states:
+        assert state.verifier is not None, (
+            f"worker state {state.id!r} is missing its verifier panel"
+        )
+        assert state.verifier.parallel_count == 3, (
+            f"{state.id} verifier must use 3 parallel votes"
+        )
+        assert state.verifier.majority_threshold == 2, (
+            f"{state.id} verifier must require 2 of 3 passing votes"
+        )
+        assert state.verifier.role == f"verify-{state.id}", (
+            f"{state.id} verifier role drift: got {state.verifier.role!r}"
+        )

--- a/tests/test_verifiers.py
+++ b/tests/test_verifiers.py
@@ -1,0 +1,396 @@
+"""Tests for the per-state verifier prompts + LLM panel handler.
+
+These tests exercise three layers:
+
+* The verifier prompt templates render cleanly through
+  :class:`ctxr.fsm.core.prompts.PromptRenderer` against both an empty
+  smoke context (register-time validation surface) and a fixture
+  ``brief + outputs`` payload.
+* The engine's structural fallback rejects mal-shaped outputs and
+  passes well-shaped outputs against each worker state's response
+  schema (the same gate the per-state verifier panel sits behind).
+* :func:`install_verifier_handler` is idempotent: repeated calls do
+  not double-register and the process-wide registration state stays
+  coherent across imports.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+import pytest
+from ctxr.fsm.core.models import Brief, VerifierVerdict
+from ctxr.fsm.core.prompts import PromptContext, PromptRenderer
+from ctxr.fsm.core.verifier import (
+    VerifierVote,
+    get_verifier_handler,
+    run_verifier,
+    set_verifier_handler,
+)
+
+from ctxr_skill_code_review import verifier_handler as vh_module
+from ctxr_skill_code_review.spec import fsm
+from ctxr_skill_code_review.verifier_handler import (
+    install_verifier_handler,
+    llm_verifier_handler,
+    load_verifier_prompt,
+)
+
+WORKER_STATE_IDS = [
+    "scan_project",
+    "tree_descend",
+    "llm_trim",
+    "tool_discovery",
+    "dispatch_specialists",
+]
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _brief_for(state_id: str) -> Brief:
+    """Build a minimal valid Brief snapshot for ``state_id``."""
+    state = fsm.get_state(state_id)
+    worker = state.worker
+    assert worker is not None, f"{state_id} must be a worker state"
+    return Brief(
+        run_id=uuid.uuid4(),
+        fsm_id=fsm.id,
+        state=state_id,
+        purpose=state.purpose,
+        preconditions=list(state.preconditions),
+        inputs={},
+        outputs_expected=list(state.outputs),
+        post_validations=list(state.post_validations),
+        transitions=[],
+        has_worker=True,
+        has_loop=False,
+        allowed_tools=list(state.allowed_tools),
+        worker=worker,
+        loop=None,
+        gate=None,
+        iteration_n=None,
+        outputs_path=None,
+        brief_id=uuid.uuid4(),
+    )
+
+
+def _good_outputs(state_id: str) -> dict[str, Any]:
+    """Return schema-valid outputs for the given worker state."""
+    if state_id == "scan_project":
+        return {
+            "project_profile": {
+                "languages": ["python"],
+                "frameworks": ["web"],
+                "monorepo": False,
+            },
+            "changed_paths": ["src/api/auth.py"],
+            "diff_stats": {"lines_changed": 12, "files_changed": 1},
+        }
+    if state_id == "tree_descend":
+        return {
+            "stage_a_candidates": [
+                {
+                    "id": "lang-python",
+                    "path": "reviewers.wiki/lang-python.md",
+                    "activation_match": ["file_globs"],
+                }
+            ],
+            "descent_path": ["root", "languages"],
+        }
+    if state_id == "llm_trim":
+        return {
+            "picked_leaves": [
+                {
+                    "id": "lang-python",
+                    "path": "reviewers.wiki/lang-python.md",
+                    "justification": "diff touches python files",
+                    "dimensions": ["correctness"],
+                }
+            ],
+            "rejected_leaves": [],
+            "coverage_rescues": [],
+        }
+    if state_id == "tool_discovery":
+        return {
+            "tool_results": [
+                {
+                    "name": "ruff",
+                    "status": "pass",
+                    "findings": 0,
+                    "output": "ok",
+                }
+            ]
+        }
+    if state_id == "dispatch_specialists":
+        return {
+            "specialist_outputs": [
+                {
+                    "id": "lang-python",
+                    "status": "completed",
+                    "findings": [
+                        {
+                            "severity": "minor",
+                            "file": "src/api/auth.py",
+                            "title": "trailing whitespace",
+                        }
+                    ],
+                }
+            ]
+        }
+    raise ValueError(f"unknown state_id: {state_id}")
+
+
+def _bad_outputs(state_id: str) -> dict[str, Any]:
+    """Return schema-INVALID outputs that the structural verifier rejects."""
+    if state_id == "scan_project":
+        # `languages` empty (violates minItems=1).
+        return {
+            "project_profile": {
+                "languages": [],
+                "frameworks": [],
+                "monorepo": False,
+            },
+            "changed_paths": [],
+            "diff_stats": {"lines_changed": 0, "files_changed": 0},
+        }
+    if state_id == "tree_descend":
+        # Candidate missing `activation_match` entirely.
+        return {
+            "stage_a_candidates": [
+                {"id": "lang-python", "path": "x"}
+            ],
+            "descent_path": [],
+        }
+    if state_id == "llm_trim":
+        # Picked leaf missing `justification`.
+        return {
+            "picked_leaves": [
+                {
+                    "id": "lang-python",
+                    "path": "x",
+                    "dimensions": ["correctness"],
+                }
+            ],
+            "rejected_leaves": [],
+            "coverage_rescues": [],
+        }
+    if state_id == "tool_discovery":
+        # `status` outside the closed set.
+        return {
+            "tool_results": [
+                {"name": "ruff", "status": "weird", "findings": 0, "output": ""}
+            ]
+        }
+    if state_id == "dispatch_specialists":
+        # Finding `severity` outside the taxonomy.
+        return {
+            "specialist_outputs": [
+                {
+                    "id": "lang-python",
+                    "status": "completed",
+                    "findings": [
+                        {
+                            "severity": "catastrophic",
+                            "file": "src/api/auth.py",
+                            "title": "x",
+                        }
+                    ],
+                }
+            ]
+        }
+    raise ValueError(f"unknown state_id: {state_id}")
+
+
+@pytest.fixture(autouse=True)
+def _reset_verifier_handler() -> Any:
+    """Ensure each test starts with the engine's structural fallback active."""
+    set_verifier_handler(None)
+    # Also reset the install flag + dispatcher inside the module so
+    # idempotency tests start from a clean slate.
+    vh_module._INSTALLED = False  # type: ignore[attr-defined]
+    saved_dispatcher = vh_module._DISPATCHER  # type: ignore[attr-defined]
+    vh_module._DISPATCHER = None  # type: ignore[attr-defined]
+    yield
+    set_verifier_handler(None)
+    vh_module._INSTALLED = False  # type: ignore[attr-defined]
+    vh_module._DISPATCHER = saved_dispatcher  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering — one parameterized test per state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state_id", WORKER_STATE_IDS)
+def test_verifier_prompt_renders_against_fixture(state_id: str) -> None:
+    """Each verifier prompt renders cleanly with a fixture brief + outputs."""
+    template = load_verifier_prompt(state_id)
+    renderer = PromptRenderer(allow_model_import=False)
+
+    # Smoke render (empty context) — mirrors register-time validation.
+    renderer.validate(template, state_id=state_id)
+
+    # Full render with a populated metadata payload.
+    brief = _brief_for(state_id)
+    outputs = _good_outputs(state_id)
+    ctx = PromptContext(
+        state_id=state_id,
+        state_kind="verifier",
+        metadata={
+            "brief": brief.model_dump(mode="json"),
+            "outputs": outputs,
+        },
+    )
+    rendered = renderer.render(template, ctx)
+
+    # Required tokens: the prompt must echo BOTH the brief and outputs
+    # JSON envelopes so the LLM judge can see what it is verifying.
+    assert "Brief" in rendered or "brief" in rendered
+    assert "Outputs" in rendered or "outputs" in rendered
+    assert "verdict" in rendered
+    assert "passed" in rendered
+    assert "rejected" in rendered
+    # The fixture outputs payload should land inside the rendered text.
+    # We don't assert byte-equality (formatting differs across filter
+    # versions) but at least one distinctive token must survive.
+    first_key = next(iter(outputs.keys()))
+    assert first_key in rendered
+
+
+# ---------------------------------------------------------------------------
+# Structural fallback — rejects bad outputs, passes good ones
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state_id", WORKER_STATE_IDS)
+def test_structural_verifier_rejects_bad_outputs(state_id: str) -> None:
+    """The engine's structural fallback rejects schema-invalid outputs.
+
+    This is the always-on safety net the per-state verifier panel sits
+    behind: even when no LLM panel is wired, malformed worker output
+    cannot slip through.
+    """
+    state = fsm.get_state(state_id)
+    assert state.verifier is not None
+    brief = _brief_for(state_id)
+    outcome = run_verifier(state.verifier, brief, _bad_outputs(state_id))
+    assert outcome.verdict is VerifierVerdict.rejected
+    assert outcome.rejected_count == state.verifier.parallel_count
+
+
+@pytest.mark.parametrize("state_id", WORKER_STATE_IDS)
+def test_structural_verifier_passes_clean_outputs(state_id: str) -> None:
+    """Well-formed outputs pass the structural fallback unanimously."""
+    state = fsm.get_state(state_id)
+    assert state.verifier is not None
+    brief = _brief_for(state_id)
+    outcome = run_verifier(state.verifier, brief, _good_outputs(state_id))
+    assert outcome.verdict is VerifierVerdict.passed
+    assert outcome.passed_count == state.verifier.parallel_count
+
+
+# ---------------------------------------------------------------------------
+# LLM panel aggregation — mock 2/3 rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state_id", WORKER_STATE_IDS)
+def test_llm_panel_majority_rejected(state_id: str) -> None:
+    """A mocked 2-of-3-rejected dispatcher produces an aggregate rejection."""
+    state = fsm.get_state(state_id)
+    assert state.verifier is not None
+
+    call_count = {"n": 0}
+
+    def fake_dispatcher(prompt: str, context: dict[str, Any]) -> str:
+        call_count["n"] += 1
+        # First two votes reject, third passes — majority is "rejected".
+        if call_count["n"] <= 2:
+            return json.dumps({"verdict": "rejected", "reason": "test reject"})
+        return json.dumps({"verdict": "passed", "reason": "test ok"})
+
+    vh_module._DISPATCHER = fake_dispatcher  # type: ignore[attr-defined]
+    set_verifier_handler(llm_verifier_handler)
+
+    brief = _brief_for(state_id)
+    outcome = run_verifier(state.verifier, brief, _good_outputs(state_id))
+
+    assert outcome.parallel_count == 3
+    assert outcome.passed_count == 1
+    assert outcome.rejected_count == 2
+    assert outcome.verdict is VerifierVerdict.rejected
+    assert call_count["n"] == 3
+
+
+@pytest.mark.parametrize("state_id", WORKER_STATE_IDS)
+def test_llm_panel_majority_passed(state_id: str) -> None:
+    """A unanimous-pass dispatcher produces an aggregate passed verdict."""
+    state = fsm.get_state(state_id)
+    assert state.verifier is not None
+
+    def fake_dispatcher(prompt: str, context: dict[str, Any]) -> str:
+        return json.dumps({"verdict": "passed", "reason": "looks fine"})
+
+    vh_module._DISPATCHER = fake_dispatcher  # type: ignore[attr-defined]
+    set_verifier_handler(llm_verifier_handler)
+
+    brief = _brief_for(state_id)
+    outcome = run_verifier(state.verifier, brief, _good_outputs(state_id))
+
+    assert outcome.verdict is VerifierVerdict.passed
+    assert outcome.passed_count == 3
+
+
+def test_llm_panel_malformed_response_fails_closed() -> None:
+    """A dispatcher returning non-JSON yields rejected votes, not a crash."""
+    state = fsm.get_state("scan_project")
+    assert state.verifier is not None
+
+    def fake_dispatcher(prompt: str, context: dict[str, Any]) -> str:
+        return "definitely not JSON"
+
+    vh_module._DISPATCHER = fake_dispatcher  # type: ignore[attr-defined]
+    set_verifier_handler(llm_verifier_handler)
+
+    brief = _brief_for("scan_project")
+    outcome = run_verifier(state.verifier, brief, _good_outputs("scan_project"))
+    assert outcome.verdict is VerifierVerdict.rejected
+    assert outcome.rejected_count == 3
+    for vote in outcome.votes:
+        assert isinstance(vote, VerifierVote)
+        assert "verifier_response_not_json" in vote.reason
+
+
+# ---------------------------------------------------------------------------
+# Installer idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_install_verifier_handler_no_dispatcher_returns_false() -> None:
+    """Without a dispatcher, install_verifier_handler leaves the fallback live."""
+    assert vh_module._DISPATCHER is None  # type: ignore[attr-defined]
+    installed = install_verifier_handler()
+    assert installed is False
+    # The engine's getter must still return None (structural fallback).
+    assert get_verifier_handler() is None
+
+
+def test_install_verifier_handler_idempotent() -> None:
+    """Calling install_verifier_handler twice does not double-register."""
+
+    def fake_dispatcher(prompt: str, context: dict[str, Any]) -> str:
+        return json.dumps({"verdict": "passed", "reason": "ok"})
+
+    vh_module._DISPATCHER = fake_dispatcher  # type: ignore[attr-defined]
+
+    first = install_verifier_handler()
+    second = install_verifier_handler()
+
+    assert first is True
+    assert second is True
+    assert get_verifier_handler() is llm_verifier_handler


### PR DESCRIPTION
## Summary

- Attach a 3-voter / 2-majority `VerifierSpec` to each of the 5 worker states (`scan_project`, `tree_descend`, `llm_trim`, `tool_discovery`, `dispatch_specialists`) with bundled Jinja2 prompts under `ctxr_skill_code_review/verifiers/`.
- Add `ctxr_skill_code_review.verifier_handler` that ships `llm_verifier_handler` + `install_verifier_handler`; wires through `install.py`, falls back to the engine's structural verifier when no LLM dispatcher is configured (`CTXR_LLM_VERIFIER_DISPATCH` env or ad-hoc `_DISPATCHER`).
- The `install.py` JSON envelope shape stays byte-stable (5 keys, unchanged).

## Test plan

- [x] `uv run ruff check ctxr_skill_code_review/ tests/` — clean
- [x] `uv run mypy ctxr_skill_code_review/` — Success: no issues found in 8 source files
- [x] `uv run pytest -m "not e2e"` — 111 passed
- [x] `python -m ctxr_skill_code_review.install` in a tmpdir — envelope shape (`db_path`, `handlers_registered`, `spec_created`, `spec_id`, `spec_version`) unchanged