### PR TITLE
fix(skill): planner picked_leaves guard + loop-empty Loop skip + post_validation

### DIFF
--- a/ctxr_skill_code_review/spec.py
+++ b/ctxr_skill_code_review/spec.py
@@ -1074,11 +1074,31 @@ def _plan_specialist_batches() -> State:
                 Predicate("len(specialist_batches) >= 0"),
                 Predicate("total_batches >= 0"),
                 Predicate("total_files_planned >= 0"),
+                # Catch the env-threading bug that produced run 019e93cb:
+                # if there ARE picked leaves but the planner emitted 0
+                # batches, the handler was fed an empty picked_leaves
+                # by an upstream env-seeding bug. Hard-fail at the gate
+                # so the fault surfaces here instead of silently flowing
+                # an empty Loop into merge_specialist_outputs.
+                Predicate(
+                    "(len(picked_leaves) == 0) OR (total_batches > 0)"
+                ),
             ],
             purpose="Deterministic batch + sub-batch planning for the loop.",
         ),
         outputs=["specialist_batches", "total_batches", "total_files_planned"],
-        transitions=[Transition(to="dispatch_specialists", when=TransitionKind.always)],
+        # PR6: when the planner emits 0 batches (no picked leaves at all),
+        # skip dispatch_specialists' Loop entirely and route straight to
+        # the merger. The merger handles an empty specialist_outputs[]
+        # gracefully; entering an empty Loop wastes a brief round-trip
+        # and complicates the Loop body's "no work to do" reasoning.
+        transitions=[
+            Transition(
+                to="merge_specialist_outputs",
+                when=Predicate("total_batches == 0"),
+            ),
+            Transition(to="dispatch_specialists", when=TransitionKind.always),
+        ],
     )
 
 
@@ -1107,6 +1127,15 @@ def _dispatch_specialists() -> State:
                     "tool_results",
                     "specialist_batches",
                     "total_batches",
+                    # PR6: declare picked_leaves on the Loop worker
+                    # explicitly so the sub-agent dispatched per
+                    # iteration has the leaf-level metadata it needs
+                    # (purpose, dimensions, justification) to review
+                    # each unit, not just the file lists carried on the
+                    # batch itself. Skipping this leaves the Loop body
+                    # working from a partial view of the leaves chosen
+                    # upstream by llm_trim.
+                    "picked_leaves",
                 ],
                 response_schema=_specialist_batch_schema(),
             ),

--- a/tests/test_handlers/test_loop_empty_path.py
+++ b/tests/test_handlers/test_loop_empty_path.py
@@ -1,0 +1,169 @@
+"""End-to-end coverage for the PR6 0-batch loop-skip path.
+
+When the planner emits ``total_batches == 0`` (because llm_trim picked
+no leaves), the spec routes the engine straight from
+``plan_specialist_batches`` to ``merge_specialist_outputs``, skipping
+``dispatch_specialists`` (the Loop) entirely.
+
+The test drives the FSM through the inline + simulated-worker path
+identical to ``test_end_to_end`` but with ``picked_leaves=[]`` so that
+the planner emits 0 batches. It asserts:
+
+* ``dispatch_specialists`` is NOT visited.
+* ``merge_specialist_outputs`` IS visited and emits an empty
+  ``specialist_outputs`` list (with no MissedFileError).
+* The terminal state is reached cleanly (no engine fault, no
+  MissedFileError); the merger emits an empty
+  ``specialist_outputs`` list and downstream synthesis treats the
+  unreviewed diff as a coverage violation (verdict NO-GO is the
+  correct safe default when llm_trim selected zero leaves).
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+from ctxr.fsm.core.engine import advance as engine_advance
+from ctxr.fsm.core.engine import execute_inline
+from ctxr.fsm.core.inline_registry import InlineHandlerRegistry
+from ctxr.fsm.core.models import RunCtx
+
+from ctxr_skill_code_review.handlers import INLINE_HANDLERS
+from ctxr_skill_code_review.spec import SPEC_ID, fsm
+
+
+def _simulated_worker_output_zero_picked(state_id: str) -> dict[str, Any]:
+    """Mirror tests/test_end_to_end._simulated_worker_output but with
+    llm_trim returning an EMPTY picked_leaves list — the upstream
+    condition that produces total_batches == 0.
+    """
+    if state_id == "scan_project":
+        return {
+            "project_profile": {
+                "languages": ["python"],
+                "frameworks": [],
+                "monorepo": False,
+            },
+            "changed_paths": ["src/example.py"],
+            "diff_stats": {"lines_changed": 50, "files_changed": 1},
+        }
+    if state_id == "tree_descend":
+        # A candidate exists but llm_trim will reject it below.
+        return {
+            "stage_a_candidates": [
+                {
+                    "id": "example-leaf",
+                    "path": "example-leaf.md",
+                    "activation_match": ["file_globs"],
+                }
+            ],
+            "descent_path": ["root", "example"],
+        }
+    if state_id == "llm_trim":
+        # The trigger condition for PR6: llm_trim picks zero leaves.
+        return {
+            "picked_leaves": [],
+            "rejected_leaves": [
+                {
+                    "id": "example-leaf",
+                    "path": "example-leaf.md",
+                    "reason": "out of scope for this diff",
+                }
+            ],
+            "coverage_rescues": [],
+        }
+    if state_id == "tool_discovery":
+        return {"tool_results": []}
+    if state_id == "dispatch_specialists":
+        # Should NEVER be reached on the 0-batch path. If we end up here
+        # the spec's PR6 short-circuit transition is broken.
+        raise AssertionError(
+            "dispatch_specialists must not be entered when total_batches == 0"
+        )
+    raise KeyError(f"no simulated output for state {state_id!r}")
+
+
+def test_zero_picked_leaves_skips_loop_and_reaches_terminal(tmp_path: Path) -> None:
+    """Drive the spec from entry to terminal with picked_leaves=[]."""
+    registry = InlineHandlerRegistry()
+    registry.register_many(SPEC_ID, INLINE_HANDLERS)
+
+    run_id = uuid.uuid4()
+    env: dict[str, Any] = {
+        "args": {"project_root": str(tmp_path), "base": "BASE", "head": "HEAD"},
+    }
+    current_state = fsm.entry
+    visited: list[str] = []
+    max_steps = 64
+
+    for step in range(max_steps):
+        state = fsm.get_state(current_state)
+        visited.append(current_state)
+        if state.kind == "terminal":
+            break
+
+        if state.kind == "inline":
+            ctx = RunCtx(
+                run_id=run_id,
+                fsm_id=fsm.id,
+                current_state=state.id,
+                env=env,
+            )
+            result = execute_inline(
+                state=state,
+                ctx=ctx,
+                args=env.get("args", {}),
+                inputs=env,
+                registry=registry,
+            )
+            assert result.ok, (
+                f"inline state {state.id} faulted: {result.fault_reason}"
+            )
+            outputs = result.outputs
+        else:
+            outputs = _simulated_worker_output_zero_picked(state.id)
+
+        ctx = RunCtx(
+            run_id=run_id,
+            fsm_id=fsm.id,
+            current_state=state.id,
+            env=env,
+        )
+        advance_result = engine_advance(fsm, ctx, outputs)
+        assert advance_result.kind != "fault", (
+            f"engine faulted at {state.id} step {step}: "
+            f"{advance_result.reason} errors={advance_result.errors}"
+        )
+        env = {**env, **outputs}
+        if advance_result.kind == "terminal":
+            visited.append("terminal")
+            break
+        current_state = advance_result.next_state or ""
+    else:
+        raise AssertionError(
+            f"FSM did not reach terminal within {max_steps} steps; visited={visited}"
+        )
+
+    # PR6 assertion: the Loop is skipped.
+    assert "dispatch_specialists" not in visited, (
+        f"dispatch_specialists must not be visited on the 0-batch path; "
+        f"visited={visited}"
+    )
+    # PR6 assertion: the merger still runs (so collect_findings has
+    # something to consume, even if the list is empty).
+    assert "merge_specialist_outputs" in visited, (
+        f"merge_specialist_outputs must still run; visited={visited}"
+    )
+    # The pipeline still reaches terminal cleanly.
+    assert visited[-1] == "terminal"
+    # The empty-merger path produced an empty specialist_outputs list.
+    assert env.get("specialist_outputs") == []
+    # No findings -> no per-finding coverage credit; no leaves -> no
+    # per-leaf coverage credit -> coverage rule is violated -> NO-GO
+    # is the correct conservative verdict. (The point of the PR6
+    # short-circuit is that we still REACH the verdict gate cleanly
+    # instead of stalling in an empty Loop.)
+    assert env.get("coverage_rule_violated") is True
+    assert env.get("verdict") == "NO-GO"

--- a/tests/test_handlers/test_plan_batches.py
+++ b/tests/test_handlers/test_plan_batches.py
@@ -180,3 +180,77 @@ def test_leaf_with_no_matched_files_still_emits_a_unit() -> None:
     unit = out["specialist_batches"][0]["units"][0]
     assert unit["leaf_id"] == "no-match"
     assert unit["files"] == []
+
+
+def test_zero_picked_leaves_emits_zero_batches() -> None:
+    """No picked_leaves -> no units -> 0 batches.
+
+    Regression marker for run 019e93cb: when an upstream env-threading
+    bug drops picked_leaves before this handler runs, the handler is
+    expected to emit ``total_batches == 0`` (NOT to crash). The
+    spec-level post_validation
+    ``(len(picked_leaves) == 0) OR (total_batches > 0)`` then takes
+    over: it PASSES this case (0 == 0) but would FAIL the buggy case
+    (picked_leaves dropped from env -> the handler still emits 0
+    batches but the predicate disagrees, surfacing the upstream bug).
+
+    The follow-on spec transition routes 0-batch runs directly to
+    merge_specialist_outputs so the empty Loop is skipped entirely;
+    see ``tests/test_handlers/test_loop_empty_path.py`` for that path.
+    """
+    out = handle_plan_specialist_batches(
+        _ctx(picked_leaves=[], changed_paths=["src/a.py", "src/b.py"], tier="lite")
+    )
+    assert out["total_batches"] == 0
+    assert out["specialist_batches"] == []
+    assert out["total_files_planned"] == 0
+
+
+def test_single_small_leaf_produces_single_batch() -> None:
+    """One leaf with a small file set -> 1 batch, 1 unit, 1 sub-index.
+
+    Matches the audit's "1 leaf small -> 1 batch" repro shape.
+    """
+    picked = [
+        {"id": "leaf-1", "path": "leaf-1.md", "activation": {"file_globs": ["src/*.py"]}}
+    ]
+    out = handle_plan_specialist_batches(
+        _ctx(picked_leaves=picked, changed_paths=["src/a.py", "src/b.py"], tier="lite")
+    )
+    assert out["total_batches"] == 1
+    assert len(out["specialist_batches"][0]["units"]) == 1
+    unit = out["specialist_batches"][0]["units"][0]
+    assert unit["sub_index"] == 1
+    assert unit["total_subs"] == 1
+    assert set(unit["files"]) == {"src/a.py", "src/b.py"}
+
+
+def test_single_huge_leaf_splits_into_multiple_sub_batches() -> None:
+    """The audit's "1 huge leaf -> sub-batches" case, exercised end-to-end.
+
+    300 files * 500 tokens = 150_000 estimated; cap 50_000 ->
+    ceil(150_000 / 50_000) = 3 sub-batches.
+    """
+    files = [f"src/huge/f{i}.py" for i in range(300)]
+    picked = [
+        {"id": "huge", "path": "huge.md", "activation": {"file_globs": ["src/huge/*.py"]}}
+    ]
+    out = handle_plan_specialist_batches(
+        _ctx(
+            picked_leaves=picked,
+            changed_paths=files,
+            tier="full",
+            args={"max_leaf_tokens": 50_000, "batch_size": 5},
+        )
+    )
+    units = [u for b in out["specialist_batches"] for u in b["units"]]
+    assert len(units) == 3
+    assert {u["sub_index"] for u in units} == {1, 2, 3}
+    assert all(u["total_subs"] == 3 for u in units)
+    # Disjoint slices, covering the full input.
+    union: set[str] = set()
+    for u in units:
+        u_files = set(u["files"])
+        assert union.isdisjoint(u_files), f"overlap: {u_files & union}"
+        union.update(u_files)
+    assert union == set(files)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -252,3 +252,75 @@ def test_each_worker_has_verifier() -> None:
         assert state.verifier.role == f"verify-{state.id}", (
             f"{state.id} verifier role drift: got {state.verifier.role!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# PR6: plan_specialist_batches gains a guard predicate + a 0-batch skip edge
+# ---------------------------------------------------------------------------
+
+
+def test_plan_specialist_batches_has_two_outgoing_transitions() -> None:
+    """PR6: plan -> (merge when 0 batches) OR (dispatch otherwise).
+
+    Before PR6 there was a single always-transition into the Loop. The
+    new edge lets us short-circuit an empty Loop when picked_leaves is
+    empty (which happens when llm_trim picks nothing OR when an env
+    threading bug drops picked_leaves between states).
+    """
+    state = fsm.get_state("plan_specialist_batches")
+    assert len(state.transitions) == 2, (
+        f"plan_specialist_batches must have 2 outgoing transitions; got "
+        f"{[(t.to, t.when) for t in state.transitions]}"
+    )
+    # First (guarded) edge: 0 batches -> merge_specialist_outputs.
+    first = state.transitions[0]
+    assert first.to == "merge_specialist_outputs"
+    assert hasattr(first.when, "expression"), (
+        "the 0-batch edge must be predicate-guarded, not an always-transition"
+    )
+    assert "total_batches == 0" in first.when.expression  # type: ignore[union-attr]
+    # Second (always) edge: dispatch the Loop.
+    second = state.transitions[1]
+    assert second.to == "dispatch_specialists"
+    assert str(getattr(second.when, "value", second.when)).lower() in {
+        "always",
+        "otherwise",
+    }
+
+
+def test_plan_specialist_batches_post_validation_guards_total_batches() -> None:
+    """PR6: register-time guard that catches the env-threading regression.
+
+    If picked_leaves is non-empty but the planner emits 0 batches, the
+    handler was fed an empty picked_leaves by an upstream bug. The
+    post_validation
+    ``(len(picked_leaves) == 0) OR (total_batches > 0)`` makes that
+    failure surface here loudly instead of silently flowing 0 work into
+    the Loop.
+    """
+    state = fsm.get_state("plan_specialist_batches")
+    assert state.inline is not None
+    expressions = [p.expression for p in state.inline.post_validations]
+    assert any(
+        "len(picked_leaves) == 0" in expr and "total_batches > 0" in expr
+        for expr in expressions
+    ), (
+        f"plan_specialist_batches must carry the planner-vs-picked_leaves "
+        f"guard predicate; got {expressions}"
+    )
+
+
+def test_dispatch_specialists_worker_inputs_include_picked_leaves() -> None:
+    """PR6: the Loop body needs picked_leaves to review each unit.
+
+    The Loop's worker dispatches a sub-agent per iteration; it must
+    receive the leaf-level metadata (purpose, dimensions, justification)
+    so the sub-agent can carry out the review the leaf specifies, not
+    just iterate file lists in the batch envelope.
+    """
+    state = fsm.get_state("dispatch_specialists")
+    assert state.loop is not None
+    assert "picked_leaves" in state.loop.worker.inputs, (
+        f"dispatch_specialists.loop.worker.inputs must include "
+        f"picked_leaves; got {state.loop.worker.inputs}"
+    )


### PR DESCRIPTION
## Summary

Three coordinated changes that make the empty-batches path safe and catch the env-threading bug audited in run 019e93cb at register-time.

- **Post-validation guard on `plan_specialist_batches`**: predicate `(len(picked_leaves) == 0) OR (total_batches > 0)`. If an upstream env-threading bug ever drops `picked_leaves` before the planner runs, the predicate hard-faults at the gate instead of silently flowing 0 work into the Loop.
- **0-batch loop skip**: when the planner emits `total_batches == 0`, the spec now transitions straight to `merge_specialist_outputs` (which already handles an empty `specialist_outputs[]` gracefully). Skips an empty Loop round-trip.
- **`picked_leaves` on the Loop worker inputs**: each `dispatch_specialists` sub-agent now receives leaf-level metadata (purpose, dimensions, justification), not just the file lists carried on the batch envelope.

## Tests added

- `tests/test_handlers/test_plan_batches.py`: zero picked_leaves -> 0 batches (regression marker for the audited bug condition at the handler boundary); 1 leaf small -> 1 batch; 1 huge leaf -> sub-batches.
- `tests/test_spec.py`: `plan_specialist_batches` now has 2 outgoing transitions (guarded `total_batches == 0` -> merge, plus always -> dispatch); the new post_validation is present; `dispatch_specialists.loop.worker.inputs` includes `picked_leaves`.
- `tests/test_handlers/test_loop_empty_path.py` (new): drives the FSM from entry to terminal with `picked_leaves=[]`; asserts `dispatch_specialists` is **not** visited, `merge_specialist_outputs` **is** visited and emits an empty list, terminal is reached cleanly with verdict NO-GO (correct conservative outcome when nothing was reviewed).

## Background

The handler itself was already correct at the `InlineContext` boundary; the bug audited in run 019e93cb lives in `fsm/ctxr/fsm/sqlite/project.py:916` (env seeding for the inline-chain driver dropped prior-state outputs). This PR ships the **skill-side defenses** so the same condition cannot silently propagate again — and adds the empty-leaves spec path that should have existed even without the underlying bug.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run mypy ctxr_skill_code_review`
- [x] `uv run pytest --ignore=tests/test_end_to_end.py` (139 passed)
- [x] `uv run pytest tests/test_end_to_end.py` (3 passed)

Generated with [Claude Code](https://claude.com/claude-code)