### PR TITLE
fix(specialists): hard-raise when dispatch loop drained early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,29 @@ upgrade to v2.4.x without any code changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- `merge_specialist_outputs` now raises `DispatchLoopExitedEarlyError`
+  when the dispatch_specialists Loop exits before draining every
+  planned `(leaf_id, sub_index)` unit. Previously the merger silently
+  emitted a partial `specialist_outputs[]` whose missing units would
+  surface in the final report as `status: fail` rows with `key_finding`
+  of `"no per-leaf output written"` (or `"no output written for shard
+  <n>"` for sharded leaves) — masking an orchestrator bug as a NO-GO
+  verdict. The error message lists the missing unit ids and points
+  the operator at the remediation: resume polling
+  `fsm.get_brief(run_id)` until the brief moves off
+  `dispatch_specialists`.
+
+### Documentation
+
+- `SKILL.md` clarifies that `dispatch_specialists` is a Loop state
+  and the orchestrator MUST keep polling `fsm.get_brief(run_id)`
+  after every iteration's commit until the engine advances to a
+  different state. Added a "DRAIN ALL ITERATIONS" warning callout
+  and a loop-until-empty pseudo-code example.
+
+
 ## [3.0.0] - Python port (W14f)
 
 ### BREAKING — Node orchestrator removed; depends on ctxr-fsm (Python)

--- a/SKILL.md
+++ b/SKILL.md
@@ -92,6 +92,37 @@ through the `fsm.*` MCP tool family:
      iteration index. Commit the iteration's output; the engine
      decides whether to advance or to issue another iteration.
 
+     > **DRAIN ALL ITERATIONS — never short-circuit the loop.** When
+     > the engine issues a Loop brief, it expects you to keep calling
+     > `fsm.get_brief(run_id)` AFTER every commit until it returns a
+     > brief for a DIFFERENT state. The engine itself decides loop
+     > termination (via the worker's `loop_done` flag and the planner's
+     > `total_batches`). One commit is one iteration; if there are
+     > N batches, you must complete N iterations.
+     >
+     > The first Loop brief carries `iteration_n = 1`. After you commit
+     > iteration 1's output the engine re-enters the same state with
+     > `iteration_n = 2` and a new brief; KEEP THE LOOP RUNNING until
+     > `fsm.get_brief` returns a brief whose `state_id` is no longer
+     > `dispatch_specialists`. The orchestrator MUST NOT exit the
+     > dispatch loop based on its own counter; only the engine knows
+     > when the planner's batches are drained.
+     >
+     > **Symptom of this bug**: the final `report.md` shows specialists
+     > with `status: fail` and `skip_reason: "no per-leaf output written"`
+     > or `"no output written for shard <n>"`, even though the orchestrator
+     > thought every dispatched sub-agent succeeded. Cause: the
+     > orchestrator committed iteration 1's outputs and then advanced
+     > past `dispatch_specialists` (e.g. by calling
+     > `merge_specialist_outputs` directly) instead of polling the next
+     > brief. The merger then sees only the first batch's units in
+     > `loop_iters`, synthesises failure rows for every undispatched
+     > unit, and the run lands at NO-GO with most reviewers silently
+     > marked failed. **The runner now hard-raises
+     > `DispatchLoopExitedEarlyError` in this situation** (instead of
+     > silently producing a degraded report) so the failure surfaces
+     > as a post-validation fault.
+
    * **Inline briefs.** You will NEVER see them. Inline states
      (`risk_tier_triage`, `activate_leaves`, `collect_findings`,
      `verify_coverage`, `synthesize_release_readiness`,
@@ -107,16 +138,78 @@ through the `fsm.*` MCP tool family:
 ## Worker dispatch — concurrency
 
 The `dispatch_specialists` state's worker is the only one that fans
-out. Its brief carries a `batch` field listing each specialist's
-leaf-id and per-leaf prompt slice. Dispatch them concurrently using
-your client's parallel-tool-call mechanism (Claude Code: multiple
-Bash / Agent tool calls in a single message; Codex: equivalent),
-collect every output, then commit the aggregated outputs dict to
-`fsm.commit_outputs` matching the worker's `response_schema`.
+out. It is a **Loop** state: the upstream `plan_specialist_batches`
+inline handler partitions every picked leaf into one or more
+deterministic batches (typically 3-5 units per batch, tier-driven),
+and the engine drives one Loop iteration per batch. Each iteration's
+brief carries:
 
-The cap on parallel specialists is the `cap` field from
-`risk_tier_triage`: `trivial=3`, `lite=8`, `full=20`, `sensitive=30`,
-overridable by `args["max-reviewers"]` (clamped to `[3, 50]`).
+* `iteration_n` — 1-based iteration counter.
+* `inputs.specialist_batches[]` — the full plan.
+* `inputs.total_batches` — the planner's expected loop length.
+
+On each iteration: dispatch every unit in
+`specialist_batches[iteration_n - 1].units[]` concurrently using your
+client's parallel-tool-call mechanism (Claude Code: multiple Task /
+Agent calls in a single message; Codex: equivalent), collect every
+sub-agent's output, then commit the aggregated payload (`{batch_index,
+iter_outputs[], loop_done}`) to `fsm.commit_outputs` matching the
+worker's `response_schema`.
+
+**Loop termination is the engine's decision, not yours.** Set
+`loop_done = (iteration_n == total_batches)` on the LAST iteration —
+but never advance past `dispatch_specialists` yourself. After every
+commit, call `fsm.get_brief(run_id)` again. As long as the next brief
+carries `state_id = "dispatch_specialists"`, you have another iteration
+to run. Only when the next brief moves on (typically to
+`merge_specialist_outputs`) is the dispatch complete.
+
+### Loop-until-empty example (pseudo-code)
+
+```python
+while True:
+    brief = fsm.get_brief(run_id)
+    if brief.terminal:
+        print(brief.run_dir_path)
+        break
+    if brief.has_loop and brief.state_id == "dispatch_specialists":
+        # One iteration = one planner batch. Drain every unit IN PARALLEL.
+        current_batch = brief.inputs["specialist_batches"][brief.iteration_n - 1]
+        iter_outputs = dispatch_units_in_parallel(current_batch["units"])
+        loop_done = brief.iteration_n == brief.inputs["total_batches"]
+        fsm.commit_outputs(run_id, outputs={
+            "batch_index": brief.iteration_n,
+            "iter_outputs": iter_outputs,
+            "loop_done": loop_done,
+        })
+        # Do NOT break here. Continue the WHILE loop so we re-poll
+        # fsm.get_brief; the engine reissues another dispatch_specialists
+        # iteration (with iteration_n + 1) until total_batches is reached.
+        continue
+    if brief.has_worker:
+        outputs = dispatch_single_agent(brief.worker)
+        fsm.commit_outputs(run_id, outputs=outputs)
+        continue
+```
+
+The cap on parallel specialists WITHIN A SINGLE ITERATION is the
+`cap` field from `risk_tier_triage`: `trivial=3`, `lite=8`, `full=20`,
+`sensitive=30`, overridable by `args["max-reviewers"]` (clamped to
+`[3, 50]`). The number of ITERATIONS is independent — that is
+`total_batches` from the planner. A 100-leaf review at the full tier
+with batch_size 5 produces 20 iterations, each dispatching up to 5
+units in parallel.
+
+### Diagnostic: `DispatchLoopExitedEarlyError`
+
+If the merger detects that `loop_iters[]` covers fewer
+`(leaf_id, sub_index)` units than `specialist_batches[]` planned, it
+raises `DispatchLoopExitedEarlyError` rather than emitting a NO-GO
+report with silently-failed specialists. The error message includes
+the missing unit ids so the operator can immediately see which
+iterations the orchestrator skipped. **The fix is always orchestrator-
+side**: resume the loop until `fsm.get_brief` moves off
+`dispatch_specialists`.
 
 ## Tool surface per state
 

--- a/ctxr_skill_code_review/handlers.py
+++ b/ctxr_skill_code_review/handlers.py
@@ -2235,6 +2235,43 @@ class MissedFileError(RuntimeError):
     """
 
 
+class DispatchLoopExitedEarlyError(RuntimeError):
+    """Raised when the dispatch_specialists Loop exited before draining all batches.
+
+    The planner emits ``specialist_batches[]`` and the engine drives
+    one Loop iteration per batch. Each iteration's commit is expected
+    to carry one entry per planned ``(leaf_id, sub_index)`` unit in
+    the current batch. When the merger sees fewer total
+    ``(leaf_id, sub_index)`` units across all iterations than the
+    planner enumerated, the orchestrator advanced past
+    ``dispatch_specialists`` instead of polling
+    :func:`~ctxr.fsm.get_brief` for the next iteration — silently
+    dropping every undispatched unit.
+
+    Two notable symptoms this guards against:
+
+    1. ``loop_iters`` covers only the first batch's units (the
+       orchestrator committed once, then jumped to the next state
+       instead of looping). Without this guard the merger would
+       emit a partial ``specialist_outputs[]`` whose specialists
+       look completed, while every undispatched leaf would silently
+       become a ``status: fail`` row in the final report keyed off
+       ``skip_reason: "no per-leaf output written"``.
+
+    2. ``loop_iters`` covers most batches but a middle iteration's
+       commit dropped one or more units (e.g. the orchestrator
+       returned a partial ``iter_outputs[]``). Same failure mode,
+       same hard-raise — the post-validation makes it surface as a
+       fault instead of a degraded report.
+
+    The error is recoverable on the orchestrator side: resume
+    iterating ``fsm.get_brief(run_id)`` until the brief's
+    ``state_id`` moves off ``dispatch_specialists``. The runner is
+    purely diagnostic — it cannot dispatch sub-agents on the
+    orchestrator's behalf.
+    """
+
+
 def _resolve_iteration_payloads(env: dict[str, Any]) -> list[dict[str, Any]]:
     """Defensively pull the per-iteration payloads out of the env.
 
@@ -2355,6 +2392,24 @@ def handle_merge_specialist_outputs(ctx: InlineContext) -> dict[str, Any]:
 
     iter_payloads = _resolve_iteration_payloads(env)
 
+    # Enumerate the full set of (leaf_id, sub_index) units the planner
+    # produced. This is the authoritative coverage set; the merger's
+    # output must include one entry per planned unit. We compute this
+    # BEFORE folding loop payloads so we can compare against the dedupe
+    # set below and raise DispatchLoopExitedEarlyError when the
+    # orchestrator skipped iterations.
+    planned_units: set[tuple[str, int]] = set()
+    for batch in specialist_batches:
+        if not isinstance(batch, dict):
+            continue
+        for unit in batch.get("units") or []:
+            if not isinstance(unit, dict):
+                continue
+            leaf_id = unit.get("leaf_id")
+            sub_index = unit.get("sub_index")
+            if isinstance(leaf_id, str) and isinstance(sub_index, int):
+                planned_units.add((leaf_id, sub_index))
+
     # Dedupe iter outputs by (leaf_id, sub_index) keeping the LAST
     # occurrence. Later iterations win because retries replay a batch
     # with fresh outputs that should overwrite the earlier attempt.
@@ -2374,6 +2429,39 @@ def handle_merge_specialist_outputs(ctx: InlineContext) -> dict[str, Any]:
             key = (leaf_id, sub_index)
             # Stamp the iter_n so the sharded filename preserves history.
             deduped[key] = {**unit_out, "__iter_n": iter_n}
+
+    # Enforce the loop-drained invariant. Every planned unit must have
+    # SOME entry in deduped — completed, failed, or skipped — because
+    # the orchestrator's Loop body returns one iter_outputs[] entry per
+    # unit in each batch. A planned unit absent from deduped means the
+    # orchestrator exited the dispatch_specialists Loop before draining
+    # all of plan_specialist_batches' batches (or returned a partial
+    # iter_outputs[] in some iteration). Either way the silent-failure
+    # mode is the same: the final report would mark every missing unit
+    # FAIL with key_finding "no per-leaf output written" / "no output
+    # written for shard <n>", and the verdict drops to NO-GO for opaque
+    # reasons. Raising here surfaces the exact missing unit ids so the
+    # orchestrator knows to resume the loop.
+    missing_units = sorted(planned_units - set(deduped.keys()))
+    if missing_units:
+        sample = ", ".join(
+            f"{leaf_id}#{sub_index}"
+            for leaf_id, sub_index in missing_units[:10]
+        )
+        suffix = (
+            f" (+{len(missing_units) - 10} more)"
+            if len(missing_units) > 10
+            else ""
+        )
+        raise DispatchLoopExitedEarlyError(
+            f"merge_specialist_outputs: {len(missing_units)} of "
+            f"{len(planned_units)} planned (leaf_id, sub_index) units "
+            f"missing from loop_iters; the dispatch_specialists Loop "
+            f"exited before draining all batches. The orchestrator must "
+            f"keep polling fsm.get_brief(run_id) after each iteration's "
+            f"commit until the brief's state_id moves off "
+            f"dispatch_specialists. Missing: {sample}{suffix}."
+        )
 
     # Materialise one shard per (leaf_id, sub_index). The shard root lives
     # under the run directory (project_root/.skill-code-review/specialists/).
@@ -2599,6 +2687,7 @@ INLINE_HANDLERS: dict[str, InlineHandler] = {
 
 __all__ = [
     "INLINE_HANDLERS",
+    "DispatchLoopExitedEarlyError",
     "MissedFileError",
     "build_report_payload",
     "handle_activate_leaves",

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -20,6 +20,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+import pytest
 from ctxr.fsm.core.engine import advance as engine_advance
 from ctxr.fsm.core.engine import execute_inline
 from ctxr.fsm.core.inline_registry import InlineHandlerRegistry
@@ -274,6 +275,183 @@ def test_pr4_plan_then_merge_seven_leaves_batch_size_three(tmp_path: Path) -> No
     specialists_root = tmp_path / ".skill-code-review" / "specialists"
     shards = sorted(specialists_root.rglob("*.json"))
     assert len(shards) == 7
+
+
+# ---------------------------------------------------------------------------
+# Regression coverage for the dispatch-loop-exited-early bug (Fix B).
+#
+# Simulates a 25-leaf review (the field-reported case). The integration
+# test fully drains the loop and asserts every planned unit lands in
+# specialist_outputs[]. A companion test demonstrates that the merger
+# hard-raises when the orchestrator exits after only the first batch.
+# ---------------------------------------------------------------------------
+
+
+def test_fix_b_orchestrator_drains_25_leaf_dispatch_no_units_lost(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: 25 leaves at batch_size 5 -> 5 iterations, every unit covered.
+
+    Mirrors the bug-report shape (20 picked leaves; many sharded so the
+    total dispatch-unit count exceeds the per-iteration batch size).
+    We assert:
+
+    * The planner emits 5 batches of 5 units each (25 units total).
+    * Driving every iteration through the merger produces 25
+      specialist_outputs[] entries (no silent drops).
+    * Each (leaf_id, sub_index) shard lands on disk.
+    """
+    from ctxr.fsm.core import InlineContext
+
+    from ctxr_skill_code_review.handlers import (
+        handle_merge_specialist_outputs,
+        handle_plan_specialist_batches,
+    )
+
+    picked = [
+        {
+            "id": f"leaf-{n:02d}",
+            "path": f"leaf-{n:02d}.md",
+            "activation": {"file_globs": [f"src/m{n:02d}/*.py"]},
+        }
+        for n in range(1, 26)
+    ]
+    changed = [f"src/m{n:02d}/x.py" for n in range(1, 26)]
+
+    plan = handle_plan_specialist_batches(
+        InlineContext(
+            run_id=uuid.uuid4(),
+            fsm_id="code-reviewer",
+            state_id="plan_specialist_batches",
+            args={"project_root": str(tmp_path), "batch_size": 5},
+            inputs={"picked_leaves": picked, "changed_paths": changed, "tier": "full"},
+        )
+    )
+    assert plan["total_batches"] == 5
+    total_units = sum(len(b["units"]) for b in plan["specialist_batches"])
+    assert total_units == 25
+
+    # The drain: drive EVERY iteration. This is the contract the
+    # orchestrator must honour — one commit per batch, total commits ==
+    # plan.total_batches. Skipping any iteration is the field bug.
+    loop_iters = []
+    for batch in plan["specialist_batches"]:
+        loop_iters.append({
+            "batch_index": batch["batch_index"],
+            "iter_outputs": [
+                {
+                    "leaf_id": u["leaf_id"],
+                    "sub_index": u["sub_index"],
+                    "specialist_output": {
+                        "id": u["leaf_id"],
+                        "status": "completed",
+                        "findings": [],
+                    },
+                }
+                for u in batch["units"]
+            ],
+            "loop_done": batch["batch_index"] == plan["total_batches"],
+        })
+
+    merged = handle_merge_specialist_outputs(
+        InlineContext(
+            run_id=uuid.uuid4(),
+            fsm_id="code-reviewer",
+            state_id="merge_specialist_outputs",
+            args={"project_root": str(tmp_path)},
+            inputs={
+                "specialist_batches": plan["specialist_batches"],
+                "total_files_planned": plan["total_files_planned"],
+                "loop_iters": loop_iters,
+            },
+        )
+    )
+    # All 25 units survive the merge.
+    assert len(merged["specialist_outputs"]) == 25
+    surviving_ids = sorted(o["id"] for o in merged["specialist_outputs"])
+    expected_ids = sorted(p["id"] for p in picked)
+    assert surviving_ids == expected_ids
+    # All 25 shards land on disk.
+    shards = sorted((tmp_path / ".skill-code-review" / "specialists").rglob("*.json"))
+    assert len(shards) == 25
+
+
+def test_fix_b_partial_drain_after_first_batch_raises_diagnostic(
+    tmp_path: Path,
+) -> None:
+    """If the orchestrator commits only batch 1, the merger raises.
+
+    This is the field-reported bug shape (orchestrator exited the loop
+    after one iteration). The merger MUST hard-fail with
+    DispatchLoopExitedEarlyError pointing at the missing batches so
+    the operator can resume rather than ship a NO-GO report claiming
+    25 specialists failed.
+    """
+    from ctxr.fsm.core import InlineContext
+
+    from ctxr_skill_code_review.handlers import (
+        DispatchLoopExitedEarlyError,
+        handle_merge_specialist_outputs,
+        handle_plan_specialist_batches,
+    )
+
+    picked = [
+        {
+            "id": f"leaf-{n:02d}",
+            "path": f"leaf-{n:02d}.md",
+            "activation": {"file_globs": [f"src/m{n:02d}/*.py"]},
+        }
+        for n in range(1, 26)
+    ]
+    changed = [f"src/m{n:02d}/x.py" for n in range(1, 26)]
+
+    plan = handle_plan_specialist_batches(
+        InlineContext(
+            run_id=uuid.uuid4(),
+            fsm_id="code-reviewer",
+            state_id="plan_specialist_batches",
+            args={"project_root": str(tmp_path), "batch_size": 5},
+            inputs={"picked_leaves": picked, "changed_paths": changed, "tier": "full"},
+        )
+    )
+
+    # Orchestrator ran ONLY iteration 1. The remaining 4 batches (20
+    # units) never made it into loop_iters.
+    first_batch = plan["specialist_batches"][0]
+    loop_iters = [{
+        "batch_index": first_batch["batch_index"],
+        "iter_outputs": [
+            {
+                "leaf_id": u["leaf_id"],
+                "sub_index": u["sub_index"],
+                "specialist_output": {
+                    "id": u["leaf_id"],
+                    "status": "completed",
+                    "findings": [],
+                },
+            }
+            for u in first_batch["units"]
+        ],
+        "loop_done": True,  # orchestrator wrongly flagged done after iter 1
+    }]
+
+    with pytest.raises(DispatchLoopExitedEarlyError) as excinfo:
+        handle_merge_specialist_outputs(
+            InlineContext(
+                run_id=uuid.uuid4(),
+                fsm_id="code-reviewer",
+                state_id="merge_specialist_outputs",
+                args={"project_root": str(tmp_path)},
+                inputs={
+                    "specialist_batches": plan["specialist_batches"],
+                    "total_files_planned": plan["total_files_planned"],
+                    "loop_iters": loop_iters,
+                },
+            )
+        )
+    msg = str(excinfo.value)
+    assert "20 of 25" in msg
+    assert "fsm.get_brief" in msg
 
 
 def test_pr4_huge_leaf_splits_into_subbatches(tmp_path: Path) -> None:

--- a/tests/test_handlers/test_merge_specialist_outputs.py
+++ b/tests/test_handlers/test_merge_specialist_outputs.py
@@ -18,7 +18,7 @@ import pytest
 from ctxr.fsm.core import InlineContext
 
 from ctxr_skill_code_review.handlers import (
-    MissedFileError,
+    DispatchLoopExitedEarlyError,
     handle_merge_specialist_outputs,
 )
 from ctxr_skill_code_review.sharding import shard_path
@@ -193,8 +193,15 @@ def test_later_iteration_overwrites_earlier_on_disk(tmp_path: Path) -> None:
     assert findings[0]["title"] == "v2"
 
 
-def test_missed_file_raises_when_planner_and_merger_disagree(tmp_path: Path) -> None:
-    """If the loop body drops a unit, the merger's union shrinks -> raise."""
+def test_missed_unit_raises_when_loop_dropped_a_planned_unit(tmp_path: Path) -> None:
+    """If the loop body drops a unit, the more-specific DispatchLoopExitedEarlyError fires.
+
+    The planner enumerated 2 units; loop_iters covers only 1. The
+    merger's defensive guard catches the missing (leaf_id, sub_index)
+    BEFORE the file-union invariant — that gives the orchestrator a
+    pointer to the exact missing unit ids instead of a "files dropped"
+    statistic.
+    """
     # Planner says total_files_planned=2 (both a.py and b.py).
     batches = [
         _unit_batch(
@@ -227,7 +234,7 @@ def test_missed_file_raises_when_planner_and_merger_disagree(tmp_path: Path) -> 
             loop_done=True,
         )
     ]
-    with pytest.raises(MissedFileError):
+    with pytest.raises(DispatchLoopExitedEarlyError, match="leaf-b#1"):
         handle_merge_specialist_outputs(
             _ctx(
                 tmp_path=tmp_path,
@@ -543,3 +550,238 @@ def test_shard_files_land_at_expected_paths(tmp_path: Path) -> None:
     data = json.loads(p1.read_text())
     assert data["id"] == "leaf-a"
     assert data["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Regression coverage for the dispatch-loop-exited-early diagnostic.
+#
+# Scenario: the orchestrator dispatched only the FIRST batch's units and
+# advanced past dispatch_specialists instead of polling fsm.get_brief for
+# the next iteration. The merger must hard-fail with
+# DispatchLoopExitedEarlyError listing the missing (leaf_id, sub_index)
+# pairs so the operator knows exactly which batches were dropped, instead
+# of silently emitting a NO-GO report with most specialists marked failed.
+# ---------------------------------------------------------------------------
+
+
+def test_loop_exited_early_after_first_batch_raises_with_missing_unit_ids(
+    tmp_path: Path,
+) -> None:
+    """Three planned batches, only batch 1's units committed -> raise.
+
+    Mirrors the field-reported bug: 25 picked leaves, planner emits N
+    batches, the orchestrator only ran iteration 1. The merger must
+    list the absent (leaf_id, sub_index) pairs in the error message so
+    the operator can confirm the exact gap.
+    """
+    # 3 batches with 2 units each = 6 planned units, only first 2 committed.
+    batches = []
+    for batch_idx in range(1, 4):
+        batches.append(
+            _unit_batch(
+                batch_idx,
+                [
+                    {
+                        "leaf_id": f"leaf-{batch_idx}a",
+                        "sub_index": 1,
+                        "total_subs": 1,
+                        "files": [f"src/{batch_idx}a.py"],
+                    },
+                    {
+                        "leaf_id": f"leaf-{batch_idx}b",
+                        "sub_index": 1,
+                        "total_subs": 1,
+                        "files": [f"src/{batch_idx}b.py"],
+                    },
+                ],
+            )
+        )
+    # Orchestrator only ran iteration 1: 2 units committed; 4 dropped.
+    loop_iters = [
+        _iter_payload(
+            1,
+            [
+                (
+                    "leaf-1a",
+                    1,
+                    {"id": "leaf-1a", "status": "completed", "findings": []},
+                ),
+                (
+                    "leaf-1b",
+                    1,
+                    {"id": "leaf-1b", "status": "completed", "findings": []},
+                ),
+            ],
+            loop_done=True,  # orchestrator wrongly thought it was done
+        )
+    ]
+    with pytest.raises(DispatchLoopExitedEarlyError) as excinfo:
+        handle_merge_specialist_outputs(
+            _ctx(
+                tmp_path=tmp_path,
+                specialist_batches=batches,
+                total_files_planned=6,
+                loop_iters=loop_iters,
+            )
+        )
+    msg = str(excinfo.value)
+    # The error names the 4 absent units so the operator can grep them.
+    assert "4 of 6" in msg
+    for absent in ("leaf-2a#1", "leaf-2b#1", "leaf-3a#1", "leaf-3b#1"):
+        assert absent in msg, f"error must list missing unit {absent!r}: {msg!r}"
+    # And it points the operator at the actual remediation (resume the loop).
+    assert "fsm.get_brief" in msg
+
+
+def test_loop_exited_early_caps_sample_at_ten_with_overflow_count(
+    tmp_path: Path,
+) -> None:
+    """Error message lists at most 10 missing ids; the rest become "(+N more)".
+
+    Keeps the diagnostic short on a worst-case 50-leaf review where the
+    orchestrator dispatched 0 batches. We assert the truncation contract
+    rather than dumping every id into the exception.
+    """
+    # 15 planned units, none committed.
+    units = [
+        {
+            "leaf_id": f"leaf-{n:02d}",
+            "sub_index": 1,
+            "total_subs": 1,
+            "files": [f"src/{n:02d}.py"],
+        }
+        for n in range(15)
+    ]
+    batches = [_unit_batch(1, units)]
+    loop_iters: list[dict[str, Any]] = []
+    with pytest.raises(DispatchLoopExitedEarlyError) as excinfo:
+        handle_merge_specialist_outputs(
+            _ctx(
+                tmp_path=tmp_path,
+                specialist_batches=batches,
+                total_files_planned=15,
+                loop_iters=loop_iters,
+            )
+        )
+    msg = str(excinfo.value)
+    assert "15 of 15" in msg
+    assert "(+5 more)" in msg
+
+
+def test_loop_exited_early_during_sharded_leaf_lists_each_subindex(
+    tmp_path: Path,
+) -> None:
+    """A leaf split into 3 sub-batches with only sub_index=1 committed -> 2 missing.
+
+    Sharded leaves were 16 of the 20 specialists in the bug report; the
+    diagnostic must distinguish "sub_index=1 ran" from "sub_index=2 and
+    sub_index=3 dropped" via the canonical leaf-id#sub-index notation.
+    """
+    units = [
+        {
+            "leaf_id": "huge-leaf",
+            "sub_index": sidx,
+            "total_subs": 3,
+            "files": [f"src/h{sidx}.py"],
+        }
+        for sidx in (1, 2, 3)
+    ]
+    batches = [_unit_batch(1, units)]
+    loop_iters = [
+        _iter_payload(
+            1,
+            [(
+                "huge-leaf",
+                1,
+                {"id": "huge-leaf", "status": "completed", "findings": []},
+            )],
+            loop_done=True,
+        )
+    ]
+    with pytest.raises(DispatchLoopExitedEarlyError) as excinfo:
+        handle_merge_specialist_outputs(
+            _ctx(
+                tmp_path=tmp_path,
+                specialist_batches=batches,
+                total_files_planned=3,
+                loop_iters=loop_iters,
+            )
+        )
+    msg = str(excinfo.value)
+    assert "huge-leaf#2" in msg
+    assert "huge-leaf#3" in msg
+    # The sub_index that DID run does NOT appear in the missing list.
+    # Slice the message past the "Missing:" prefix to avoid false negatives.
+    missing_section = msg.split("Missing:", 1)[1]
+    assert "huge-leaf#1" not in missing_section
+
+
+def test_loop_fully_drained_passes_no_diagnostic(tmp_path: Path) -> None:
+    """Happy path: every planned unit covered -> merger succeeds, no error.
+
+    This is the regression guard against the new check over-firing on
+    correct runs. We use 3 batches with 2 units each and commit every
+    iteration; the merger returns 6 specialist_outputs with no fault.
+    """
+    batches = []
+    for batch_idx in range(1, 4):
+        batches.append(
+            _unit_batch(
+                batch_idx,
+                [
+                    {
+                        "leaf_id": f"leaf-{batch_idx}a",
+                        "sub_index": 1,
+                        "total_subs": 1,
+                        "files": [f"src/{batch_idx}a.py"],
+                    },
+                    {
+                        "leaf_id": f"leaf-{batch_idx}b",
+                        "sub_index": 1,
+                        "total_subs": 1,
+                        "files": [f"src/{batch_idx}b.py"],
+                    },
+                ],
+            )
+        )
+    loop_iters = []
+    for batch_idx in range(1, 4):
+        loop_iters.append(
+            _iter_payload(
+                batch_idx,
+                [
+                    (
+                        f"leaf-{batch_idx}a",
+                        1,
+                        {
+                            "id": f"leaf-{batch_idx}a",
+                            "status": "completed",
+                            "findings": [],
+                        },
+                    ),
+                    (
+                        f"leaf-{batch_idx}b",
+                        1,
+                        {
+                            "id": f"leaf-{batch_idx}b",
+                            "status": "completed",
+                            "findings": [],
+                        },
+                    ),
+                ],
+                loop_done=(batch_idx == 3),
+            )
+        )
+    out = handle_merge_specialist_outputs(
+        _ctx(
+            tmp_path=tmp_path,
+            specialist_batches=batches,
+            total_files_planned=6,
+            loop_iters=loop_iters,
+        )
+    )
+    assert len(out["specialist_outputs"]) == 6
+    ids = sorted(o["id"] for o in out["specialist_outputs"])
+    assert ids == [
+        "leaf-1a", "leaf-1b", "leaf-2a", "leaf-2b", "leaf-3a", "leaf-3b",
+    ]


### PR DESCRIPTION
## Summary

- `handle_merge_specialist_outputs` now compares the planner's full set of `(leaf_id, sub_index)` units against `loop_iters`' deduped keys and raises `DispatchLoopExitedEarlyError` listing the missing ids when they disagree. Previously the merger silently emitted a partial `specialist_outputs[]`, leaving the missing units to surface as opaque `status: fail` rows with `key_finding: "no per-leaf output written"` (or `"no output written for shard <n>"` for sharded leaves) and dropping the verdict to NO-GO with no useful diagnostic.
- `SKILL.md` gains a **DRAIN ALL ITERATIONS** warning callout plus a loop-until-empty pseudo-code example so the orchestrator-side contract is unambiguous: keep polling `fsm.get_brief(run_id)` after every iteration's commit until the brief's `state_id` moves off `dispatch_specialists`.
- Documents the new diagnostic in the SKILL.md concurrency section and CHANGELOG.md.

## Field-reported symptom

A 20-picked-leaf review with sharding produced 36 prompt files but only 10 per-leaf outputs because the orchestrator committed only the first iteration (5 leaves x 2 shards = 10 units) and then advanced past `dispatch_specialists` instead of polling for iteration 2. The final report marked 14 specialists FAIL with skip_reason "no per-leaf output written" / "no output written for shard <n>" and verdict NO-GO. The new check turns this into a hard fault pointing at the missing unit ids.

## Test plan

- [x] `uv run ruff check ctxr_skill_code_review/ tests/` (clean)
- [x] `uv run mypy ctxr_skill_code_review/` (Success: no issues found in 8 source files)
- [x] `uv run pytest` (148 passed)
- [x] 4 new unit tests in `test_merge_specialist_outputs.py` for diagnostic message, 10-id truncation, sharded-leaf partial drains, and happy path
- [x] 2 new integration tests in `test_end_to_end.py` simulating 25-leaf @ batch_size 5 (fully drained + early-exit cases)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>